### PR TITLE
Support `setup.py test --coverage` in affiliated packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__
 
 # Other generated files
 */version.py
+htmlcov
+.coverage
 
 # Sphinx
 _build

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,18 @@ will be clear from context what to do with your particular VCS.
     git mv docs/packagename docs/yourpkg
     git commit -m "Updated docs to reflect new project yourpkg"
 
+* (Optional) If you want integrated coverage testing, update the
+  coverage configuration.  Open ``yourpkg/tests/coveragerc`` in a text
+  editor and change the ``source = packagename`` line to refer to the
+  name of your package.  Any other project-specific settings for
+  ``coverage.py`` can be added here.  Open
+  ``yourpkg/tests/setup_package.py`` and replace the package name
+  ``packages.tests`` with ``yourpkg.tests``.  Then do::
+
+    git add yourpkg/tests/coveragerc
+    git add yourpkg/tests/setup_package.py
+    git commit -m "Update coveragerc settings"
+
 * Adjust the ``MANIFEST.in`` file to reflect your package's name by changing
   the line 4 from ``recursive-include packagename *.pyx *.c`` to
   ``recursive-include yourpkg *.pyx *.c`` and pass this onto git::

--- a/packagename/tests/coveragerc
+++ b/packagename/tests/coveragerc
@@ -1,0 +1,20 @@
+[run]
+source = packagename
+
+[report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+
+   # Don't complain about packages we have installed
+   except ImportError
+
+   # Don't complain if tests don't hit assertions
+   raise AssertionError
+   raise NotImplementedError
+
+   # Don't complain about script hooks
+   def main\(.*\):
+
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}

--- a/packagename/tests/setup_package.py
+++ b/packagename/tests/setup_package.py
@@ -1,0 +1,3 @@
+def get_package_data():
+    return {
+        'packagename.tests': ['coveragerc']}


### PR DESCRIPTION
Fixes #25.  Requires https://github.com/astropy/astropy/issues/2132.
