### PR TITLE
Use wheels on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,46 +7,120 @@ python:
     - 3.3
 
 env:
-    # try all python versions with the latest stable numpy and astropy
-    - ASTROPY_VERSION=stable NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+    global:
+        - WHEELHOUSE_HUB=http://wheels.astropy.org
+        - PIP_WHEEL_STRICT_NUMPY="pip install --use-wheel --no-index"
+        - SETUP_CMD='test'
+        - ASTROPY_VERSION=stable
+        - PIP_WHEEL_FLEX_NUMPY="pip install --use-wheel --find-links=http://wheels.astropy.org --find-links=http://wheels2.astropy.org"
+        # All tests explicitly added to the matrix in the include section use
+        # the latest stable numpy.
+        - LATEST_NUMPY_STABLE=1.8.1
+
+        # Does your package need Cython to build?
+        - PACKAGE_NEEDS_CYTHON=true
+        # Note that cython will be installed when it is needed for building
+        # astropy development regardless of the setting of this variable.
+
+        # ADDITIONAL PACKAGE DEPENDENCIES, if any
+
+        # If there is a wheel available that will be used, otherwise the
+        # package will be built from the source at pypi.org
+
+        # If your package needs any additional packages for all builds
+        # that you want to ensure have been built with the same version of
+        # numpy used in the tests, put them here.
+        # - ADDITIONAL_DEPENDENCIES_STRICT_NUMPY="scipy"
+
+        # If your package needs additional packages for which the numpy
+        # version does not matter, put them here.
+        # - ADDITIONAL_DEPENDENCIES_ANY_NUMPY="mock requests"
+
+    # Try all python versions with all supported numpy,
+    # latest stable scipy and astropy.
+    matrix:
+        - NUMPY_VERSION=1.5.1
+        - NUMPY_VERSION=1.6.2
+        - NUMPY_VERSION=1.7.1
+        - NUMPY_VERSION=1.8.1
+        - SETUP_CMD="egg_info" ASTROPY_VERSION="none" ADDITIONAL_DEPENDENCIES_STRICT_NUMPY="" ADDITIONAL_DEPENDENCIES_ANY_NUMPY=""
 
 matrix:
-    include:
-        - python: 2.7
-          # opdeps needed because the matplotlib sphinx extension requires them
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='build_sphinx -w -n'
-
-        # try alternate numpy versions with the latest stable astropy
-        - python: 2.7
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
-        - python: 2.7
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.5.1 SETUP_CMD='test'
+    # some version of numpy do not work on some versions of python
+    exclude:
+        - python: 2.6
+          env: NUMPY_VERSION=1.6.2
+        - python: 2.6
+          env: NUMPY_VERSION=1.7.1
         - python: 3.2
-          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
-        # numpy < 1.6 does not work on py 3.x
-
-        # try latest developer version of astropy
-        - python: 2.7
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.5.1
+        - python: 3.2
+          env: NUMPY_VERSION=1.7.1
+        - python: 3.2
+          env: NUMPY_VERSION=1.8.1
         - python: 3.3
-          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.5.1
+        - python: 3.3
+          env: NUMPY_VERSION=1.6.2
+        - python: 3.3
+          env: NUMPY_VERSION=1.7.1
+
+    include:
+        # Try latest development version of astropy with latest python 2.7 and
+        # 3.x releases
+        - python: 2.7
+          env: ASTROPY_VERSION=development NUMPY_VERSION=$LATEST_NUMPY_STABLE SETUP_CMD='test'
+        - python: 3.3
+          env: ASTROPY_VERSION=development NUMPY_VERSION=$LATEST_NUMPY_STABLE SETUP_CMD='test'
+
+        # get test coverage from a python 2.7 build
+        # for now need the development version of astropy
+        - python: 2.7
+          env: ASTROPY_VERSION=development NUMPY_VERSION=$LATEST_NUMPY_STABLE SETUP_CMD='test --coverage'
+
+        # one documentation build
+        - python: 2.7
+          env: NUMPY_VERSION=$LATEST_NUMPY_STABLE SETUP_CMD='build_sphinx -w -n'
 
 before_install:
-   # We do this to make sure we get the dependencies so pip works below
-   - sudo apt-get update -qq
-   - sudo apt-get install -qq python-numpy python-sphinx cython libatlas-dev liblapack-dev gfortran
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
+    - pip install --upgrade setuptools
+    - pip install --upgrade pip
+    - pip install wheel
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get update; sudo apt-get install graphviz; fi
 
 install:
-   - export PYTHONIOENCODING=UTF8 # just in case
-   - pip -q install --upgrade "numpy==$NUMPY_VERSION" --use-mirrors
-   - pip -q install --upgrade Cython --use-mirrors
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx==1.1.3 --use-mirrors; fi
-   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install matplotlib --use-mirrors; fi
+    - export PYTHONIOENCODING=UTF8 # just in case
 
-   - if [[ $ASTROPY_VERSION == stable ]]; then pip -q install astropy --use-mirrors; fi
-   - if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy --use-mirrors; fi
+    # numpy version-specific wheelhouse
+    - export WHEELHOUSE_SPOKE=$WHEELHOUSE_HUB/numpy-$NUMPY_VERSION/
+
+    # all tests need numpy
+    # Install from wheels, no building from source, force reinstall to make
+    # sure we get our wheels.
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_STRICT_NUMPY --find-links=$WHEELHOUSE_SPOKE --upgrade --force-reinstall numpy==$NUMPY_VERSION; fi
+    - if [[ $ADDITIONAL_DEPENDENCIES_STRICT_NUMPY ]]; then $PIP_WHEEL_STRICT_NUMPY --find-links=$WHEELHOUSE_SPOKE --upgrade --force-reinstall $ADDITIONAL_DEPENDENCIES_STRICT_NUMPY; fi
+    - if [[ $ADDITIONAL_DEPENDENCIES_ANY_NUMPY ]]; then $PIP_WHEEL_FLEX_NUMPY $ADDITIONAL_DEPENDENCIES_ANY_NUMPY; fi
+
+    # tests with astropy stable use wheels
+    - if [[ $ASTROPY_VERSION == stable ]]; then $PIP_WHEEL_STRICT_NUMPY --find-links=$WHEELHOUSE_SPOKE astropy; fi
+
+    # Build development astropy from source -- requires cython. Cython does not
+    # depend on numpy so we don't care where we get the wheel from.
+    - if [[ $SETUP_CMD != egg_info && ( $ASTROPY_VERSION == development || $PACKAGE_NEEDS_CYTHON == true ) ]]; then $PIP_WHEEL_FLEX_NUMPY cython; fi
+    - if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy; fi
+
+    # Documentation build has a couple of additional requirements.
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_FLEX_NUMPY sphinx>=1.2; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_WHEEL_FLEX_NUMPY matplotlib; fi
+
+    # coverage needs the coverage package...
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coverage; fi
+    # Uncomment line below if coveralls.io is set up for this package
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then pip install coveralls; fi
 
 script:
    - python setup.py $SETUP_CMD
 
+after_success:
+    # Uncomment line below if coveralls.io is set up for this package.
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls; fi

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,10 @@ will be clear from context what to do with your particular VCS.
   `here <https://github.com/astropy/astropy/wiki/travis-ci-test-status>`_.
   Generally you should aim to always have your `master` branch work with
   the latest stable as well as the latest development version of astropy
-  (i.e. the astropy git master branch).
+  (i.e. the astropy git master branch) and the same versions of python and
+  numpy supported by astropy. The template ``.travis.yml`` covers those
+  versions; in some circumstances you may need to limit the versions your
+  package covers.
 
 * You're now ready to start doing actual work on your affiliated package.  You
   will probably want to read over the developer guidelines of the Astropy


### PR DESCRIPTION
Care is taken to use a numpy wheel whose version matches the scipy/astropy wheels.

This is an alternative to https://github.com/astropy/package-template/pull/37 that also addresses #24 and hopefully addresses the issue that @cdeil had with https://github.com/astropy/package-template/pull/37.

An example of the builds it produces on travis is at https://travis-ci.org/astropy/ccdproc/builds/21107695

There are at least few things that should be done before this is merged, if this seems like the way to go:
- [x] Move the wheels on my server to either of the astropy wheelhouses (I'm willing to host, but adding a third place to look doesn't seem helpful).
- [x] Address omission of `-w` in sphinx build
- ~~[ ] Confirm what the minimum coverage expectations are for affiliated packages.~~

The script that produced these wheels on an Ubuntu VM isn't included in this PR, though I'm happy to share it.

EDIT may 7 2014: cross off coverage expectations for packages
