### PR TITLE
removed setuptools_bootstrap.py as it doesn't exist any more

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include README.rst
 
 include ez_setup.py
+include ah_bootstrap.py
+include setup.cfg
 
 recursive-include docs *
 recursive-include licenses *


### PR DESCRIPTION
Minor problem - I'm just updating my package to the new structure and saw that this might be wrong
