### PR TITLE
Affiliated packages can opt-in to deprecations-as-exceptions

### DIFF
--- a/packagename/conftest.py
+++ b/packagename/conftest.py
@@ -3,3 +3,7 @@
 # no matter how it is invoked within the source tree.
 
 from astropy.tests.pytest_plugins import *
+
+## Uncomment the following line to treat all DeprecationWarnings as
+## exceptions
+# enable_deprecations_as_exceptions()

--- a/packagename/tests/test_example.py
+++ b/packagename/tests/test_example.py
@@ -5,3 +5,10 @@ def test_primes_c():
 def test_primes():
     from ..example_mod import primes
     assert primes(10) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+def test_deprecation():
+    import warnings
+    warnings.warn(
+        "This is deprecated, but shouldn't raise an exception, unless "
+        "enable_deprecations_as_exceptions() called from conftest.py",
+        DeprecationWarning)


### PR DESCRIPTION
Requires astropy/astropy#2572 to pass.
