### PR TITLE
Include astropy_helpers in the affilated package's tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,7 @@ recursive-include scripts *
 exclude *.pyc *.o
 prune docs/_build
 prune build
+
+recursive-include astropy_helpers *
+exclude astropy_helpers/.git
+exclude astropy_helpers/.gitignore


### PR DESCRIPTION
This is the corollary of astropy/astropy#2589 and astropy/astropy#2549.
