### PR TITLE
example file for readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,17 @@ will be clear from context what to do with your particular VCS.
   to modify the ``coveralls --rcfile`` line in ``.travis.yml`` file to
   replace ``packagename`` with the name of your package.
 
+* If you want the documentation for your project to be hosted by
+  `ReadTheDocs <https://readthedocs.org>`_, then you need to setup an
+  account there. The following entries in "Advanced Settings" for your
+  package on `ReadTheDocs <https://readthedocs.org>`_ should work:
+
+  - activate ``Install your project inside a virtualenv using setup.py install``
+  - Requirements file: ``docs/rtd-pip-requirements``
+  - activate ``Give the virtual environment access to the global site-packages dir.``
+
+  All other settings can stay on their default value.
+
 * You're now ready to start doing actual work on your affiliated package.  You
   will probably want to read over the developer guidelines of the Astropy
   documentation, and if you are hosting your code in GitHub, you might also

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+Cython
+astropy-helpers
+astropy


### PR DESCRIPTION
Most affiliated packages will probably use readthedocs. Maybe we should have a minimal 'rtd-pip-requirements' file with some comments about how to set up readthedocs (build in virtualenv, ...) ?

This is an issue and not a PR because I not quite sure what the minimal requirements are. Probably something like:

```
-e git+http://github.com/astropy/astropy-helpers.git#egg=astropy_helpers
-e git+http://github.com/astropy/astropy.git#egg=astropy
```

EDIT: Now it is a PR.
