### PR TITLE
Add coveralls --rcfile option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,4 +113,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,10 @@ will be clear from context what to do with your particular VCS.
   versions; in some circumstances you may need to limit the versions your
   package covers.
 
+* If you register your package with coveralls.io, then you will need
+  to modify the ``coveralls --rcfile`` line in ``.travis.yml`` file to
+  replace ``packagename`` with the name of your package.
+
 * You're now ready to start doing actual work on your affiliated package.  You
   will probably want to read over the developer guidelines of the Astropy
   documentation, and if you are hosting your code in GitHub, you might also


### PR DESCRIPTION
This allows `coveralls` to read the `coveragerc` file, making local coverage reports agree with `coveralls`.  See https://github.com/astropy/astropy/pull/2631.
