### PR TITLE
Added files to ignore in affiliated package coverage tests

### DIFF
--- a/packagename/tests/coveragerc
+++ b/packagename/tests/coveragerc
@@ -1,5 +1,16 @@
 [run]
 source = {packagename}
+omit =
+   {packagename}/_astropy_init*
+   {packagename}/conftest*
+   {packagename}/cython_version*
+   {packagename}/setup_package*
+   {packagename}/*/setup_package*
+   {packagename}/*/*/setup_package*
+   {packagename}/tests/*
+   {packagename}/*/tests/*
+   {packagename}/*/*/tests/*
+   {packagename}/version*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
This seems like a sensible default?
