### PR TITLE
Add info about a specific Sphinx version check.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,11 @@ setup_cfg = dict(conf.items('metadata'))
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.1'
+#needs_sphinx = '1.2'
+
+# To perform a Sphinx version check that needs to be more specific than
+# major.minor, call `check_sphinx_version("x.y.z")` here.
+# check_sphinx_version("1.2.1")
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
This is related to astropy/astropy#2667 and astropy/astropy-helpers#50.  It needs to include the related astropy-helpers submodule bump from astropy/astropy-helpers#50 for the comment to be correct.
