### PR TITLE
Replace development astropy with stable astropy for the test coverage case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,9 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2. This requires the latest
-        # development version of Astropy, which fixes some issues with
-        # coverage testing in affiliated packages.
+        # Do a coverage test in Python 2. 
         - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time


### PR DESCRIPTION
Getting accurate test coverage for affiliated packages used to require the development astropy, but those changes are in astropy 0.4.
