### PR TITLE
Change to `use_2to3=False` in `setup.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
+.project
+.pydevproject
+.settings
 
 # Mac OSX
 .DS_Store

--- a/packagename/__init__.py
+++ b/packagename/__init__.py
@@ -12,4 +12,4 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    from example_mod import *
+    from .example_mod import *

--- a/packagename/example_mod.py
+++ b/packagename/example_mod.py
@@ -16,7 +16,7 @@ def primes(imax):
         The list of prime numbers.
     """
 
-    p = range(10000)
+    p = list(range(10000))
     result = []
     k = 0
     n = 2

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
This PR changes to `use_2to3 = False` for `package-template`, which I think should be the default.