### PR TITLE
Remove affiliated package instructions from README page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,19 @@
 Astropy affiliated package template
 ===================================
 
-This is the package-template for Astropy affiliated packages.
+This is the template for affiliated packages of the Astropy project.
 
-* Code: https://github.com/astropy/package-template
-* Docs: http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html
+Astropy affiliated packages are astronomy-related Python packages that
+have requested to be part of the Astropy project’s community.
+Such packages can make use of the setup, installation, and documentation
+infrastructure developed for the ``astropy`` core package simply by
+using this template to lay out the package.
+
+For more information, see:
+
+* `Detailed instructions for using this template <http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html>`_
+* `The Affiliated Packages section of the Astropy web site <http://affiliated.astropy.org>`_
+* `This template's Github code repository <https://github.com/astropy/package-template>`_
 
 Status reports for developers
 -----------------------------


### PR DESCRIPTION
This pull request removes the instructions from the README page.

This has been discussed and I think agreed on in #96.
https://github.com/astropy/astropy/pull/2800 should be merged first.

cc @astrofrog @eteq @mwcraig
