### PR TITLE
add powered by astropy badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Astropy affiliated package template
 ===================================
 
+.. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
+    :target: http://www.astropy.org
+    :alt: Powered by Astropy Badge
+
 This is the template for affiliated packages of the Astropy project.
 
 Astropy affiliated packages are astronomy-related Python packages that


### PR DESCRIPTION
This simply adds a badge that says "powered by astropy" to the template, as per @astrofrog's suggestion in astropy/astropy.github.com#48