### PR TITLE
Update MANIFEST.in to global-exclude .pyc and .o files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,20 +1,22 @@
 include README.rst
+include CHANGES.rst
 
 include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
 
+recursive-include *.pyx *.c *.pxd
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
 
-prune docs/_build
 prune build
+prune docs/_build
+prune docs/api
 
 recursive-include astropy_helpers *
 exclude astropy_helpers/.git
 exclude astropy_helpers/.gitignore
 
-exclude *.pyc *.o
-prune docs/api
+global-exclude *.pyc *.o

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -7,6 +7,12 @@ be removed in affiliated packages.
 
 - Use setuptools entry_points for command line scripts
 
+- Included CHANGES.rst in MANIFEST.in.
+
+- Recursive include *.pyx, *.c, and *.pxd files in MANIFEST.in.
+
+- Global exclude *.pyc and *.o files in MANIFEST.in.
+
 0.4.1 (2014-10-22)
 ------------------
 


### PR DESCRIPTION
The main changes are to `global-exclude *.pyc *.o` instead of simply `exclude` and to `include CHANGES.rst`.