### PR TITLE
Changed the import from astropy to astropy_helpers 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 ## -- Options for the edit_on_github extension ----------------------------------------
 
 if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['astropy.sphinx.ext.edit_on_github']
+    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
 
     versionmod = __import__(setup_cfg['package_name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']


### PR DESCRIPTION
In the conf.py in the docs directory, it was trying to import from astropy and not astropy_helpers if the edit_on_github parameter was set.   This is a small change to switch to the correct import statement so it compiles and build the documentation.  

The error that was being produced was:
```
Traceback (most recent call last):
  File "<stdin>", line 27, in <module>
  File "/usr/local/lib/python2.7/site-packages/sphinx/application.py", line 119, in __init__
    self.setup_extension(extension)
  File "/usr/local/lib/python2.7/site-packages/sphinx/application.py", line 336, in setup_extension
    err)
sphinx.errors.ExtensionError: Could not import extension astropy.sphinx.ext.edit_on_github (exception: No module named edit_on_github)

```

Related to https://github.com/astropy/astroquery/issues/478