### PR TITLE
Update conf.py to use astropy_helpers.sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 ## -- Options for the edit_on_github extension ----------------------------------------
 
 if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['astropy.sphinx.ext.edit_on_github']
+    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
 
     versionmod = __import__(setup_cfg['package_name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']


### PR DESCRIPTION
This updates the conf.py file in the docs to use `astropy_helpers.sphinx` instead of `astropy.sphinx` (which was removed in v1.0).

@astrofrog @embray - I couldn't find anywhere obvious in the changelogs indicating that `astropy.sphin` was removed in v1.0... It was, wasn't it?  Is it documented somewhere?