### PR TITLE
Default to enabling doctest_plus

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ show-response = 1
 [pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
+doctest_plus = enabled
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This closes #35 by ending the relevant line to ``setup.cfg``.

I *think* it sounded like there was agreement in #35 we should do this.  @astrofrog, @embray, @mdboom, @weaverba137, and/or @cdeil, sound good to you?