### PR TITLE
Adding package version number rather than Astropy's to pytest header

### DIFF
--- a/packagename/conftest.py
+++ b/packagename/conftest.py
@@ -23,7 +23,8 @@ from astropy.tests.pytest_plugins import *
 ## running the tests.
 # import os
 #
-## This is to figure out the astroquery version, rather than using Astropy's
+## This is to figure out the affiliated package version, rather than
+## using Astropy's
 # from . import version
 #
 # try:

--- a/packagename/conftest.py
+++ b/packagename/conftest.py
@@ -12,7 +12,22 @@ from astropy.tests.pytest_plugins import *
 ## from the list of packages for which version numbers are displayed
 ## when running the tests
 # try:
+#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
 #     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
 #     del PYTEST_HEADER_MODULES['h5py']
 # except NameError:  # needed to support Astropy < 1.0
+#     pass
+
+## Uncomment the following lines to display the version number of the
+## package rather than the version number of Astropy in the top line when
+## running the tests.
+# import os
+#
+## This is to figure out the astroquery version, rather than using Astropy's
+# from . import version
+#
+# try:
+#     packagename = os.path.basename(os.path.dirname(__file__))
+#     TESTED_VERSIONS[packagename] = version.version
+# except NameError:   # Needed to support Astropy <= 1.0.0
 #     pass


### PR DESCRIPTION
This is the affiliated package side of astropy/astropy#3543, that allows to print the version number of the package when the test suite is run, rather than printing astropy's version number.