### PR TITLE
add .cpp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 *.so
 __pycache__
 
-# Ignore .c files by default to avoid including generated code. If you want to
+# Ignore C/C++ files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.
 *.c
+*.cpp
 
 # Other generated files
 */version.py


### PR DESCRIPTION
As discussed in astropy/astropy-helpers#173, this adds .cpp files to the ``.gitignore`` for packages that use C++ Cython extensions.