### PR TITLE
Use timeout to make sure egg_info builds don’t run for too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,14 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - TIMEOUT=3600
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython'
     matrix:
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
+        - SETUP_CMD='egg_info' TIMEOUT=30
         # Try all python versions with the latest numpy
         - SETUP_CMD='test'
 
@@ -99,7 +100,7 @@ install:
     # other dependencies.
 
 script:
-   - python setup.py $SETUP_CMD
+   - timeout $TIMEOUT python setup.py $SETUP_CMD;
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line


### PR DESCRIPTION
In https://github.com/astropy/package-template/pull/131, a change in the setup requirements caused the egg_info builds to install all dependencies and then return the correct result, which was not caught as a failure. In this PR, I've made it so that we essentially fail if `egg_info` takes more than 10 seconds to run.

@embray @cmccully - what do you think about this?
