### PR TITLE
Assumptions about data subpackage and package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ package_info = get_package_info()
 
 # Add the project-global data
 package_info['package_data'].setdefault(PACKAGENAME, [])
-package_info['package_data'][PACKAGENAME].append('data/*')
+package_info['package_data'][PACKAGENAME].append('data/*.*')
 
 # Define entry points for command-line scripts
 entry_points = {'console_scripts': []}

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', 'http://astropy.org')
+PACKAGE_DATA_PATH = metadata.get('package_data_path', 'data/*')
 
 # Get the long description from the package's docstring
 __import__(PACKAGENAME)
@@ -76,7 +77,8 @@ package_info = get_package_info()
 
 # Add the project-global data
 package_info['package_data'].setdefault(PACKAGENAME, [])
-package_info['package_data'][PACKAGENAME].append('data/*.*')
+if PACKAGE_DATA_PATH.lower() != 'none':
+    package_info['package_data'][PACKAGENAME].append(PACKAGE_DATA_PATH)
 
 # Define entry points for command-line scripts
 entry_points = {'console_scripts': []}


### PR DESCRIPTION
In one of my projects based off of this package template, I have a `data` subpackage for loading and interacting with data -- not a container for data files. The glob pattern `data/*` in `setup.py` was picking up sub-directories and trying to add them to package data, causing errors like:

```
error: can't copy 'ophiuchus/data/__pycache__': doesn't exist or not a regular file
```

In this PR, I've added support for a `package_data_path` keyword in `setup.cfg`, which can be set to `None` to turn off the default assumption. Not sure this is the best solution, but it's an idea...