### PR TITLE
Adding no_heading to api references 

### DIFF
--- a/docs/packagename/index.rst
+++ b/docs/packagename/index.rst
@@ -8,3 +8,4 @@ Reference/API
 =============
 
 .. automodapi:: packagename
+    :no-heading:


### PR DESCRIPTION
to avoid extra repetition of package and link on generated page.
