### PR TITLE
Custom header add KeyError exception

### DIFF
--- a/packagename/conftest.py
+++ b/packagename/conftest.py
@@ -8,14 +8,15 @@ from astropy.tests.pytest_plugins import *
 ## exceptions
 # enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries
-## from the list of packages for which version numbers are displayed
-## when running the tests
+## Uncomment and customize the following lines to add/remove entries from
+## the list of packages for which version numbers are displayed when running
+## the tests. Making it pass for KeyError is essential in some cases when
+## the package uses other astropy affiliated packages.
 # try:
 #     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
 #     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
 #     del PYTEST_HEADER_MODULES['h5py']
-# except NameError:  # needed to support Astropy < 1.0
+# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
 #     pass
 
 ## Uncomment the following lines to display the version number of the


### PR DESCRIPTION
This a workaround until https://github.com/astropy/astropy/issues/3664 is implemented.

In case when multiple packages using the package template, and importing each other, in rare cases both package tries to use their ``conftest.py`` a KeyError can occur. E.g:

``gwcs`` imports ``pyasdf.tests.helpers``, that imports from its ``..conftest``.

However, ``conftest.py`` exists in both packages, and as they both use the astropy package-template, both has ``PYTEST_HEADER_MODULES`` variable. None of the packages has the dependency of ``h5py``, and trying to delete it from the ``PYTEST_HEADER_MODULES`` dict twice raises an Error.

```
==================================== ERRORS ====================================
 ERROR collecting lib.macosx-10.10-x86_64-2.7/gwcs/tags/tests/test_selector.py _
gwcs/tags/tests/test_selector.py:11: in <module>
    from pyasdf.tests import helpers
/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/pyasdf/tests/helpers.py:13: in <module>
    from ..conftest import RangeHTTPServer
/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/pyasdf/conftest.py:22: in <module>
    del PYTEST_HEADER_MODULES['h5py']
/sw/lib/python2.7/collections.py:73: in __delitem__
    dict_delitem(self, key)
E   KeyError: u'h5py'
====================== 52 passed, 1 error in 4.05 seconds ======================
```

cc @astrofrog @embray 