### PR TITLE
Remove adjust_compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
 builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
-    register_commands, adjust_compiler, get_debug_option, get_package_info)
+    register_commands, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -55,10 +55,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,


### PR DESCRIPTION
This updates the helpers to the latest master, which includes a change that makes the ``adjust_compiler`` call unnecessary by building it into `build_ext` (astropy/astropy-helpers#76).

Note that astropy/astropy#4369 does the same thing in the core