### PR TITLE
Update setup.py and MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,8 +15,26 @@ prune build
 prune docs/_build
 prune docs/api
 
-recursive-include astropy_helpers *
-exclude astropy_helpers/.git
-exclude astropy_helpers/.gitignore
+
+# the next few stanzas are for astropy_helpers.  It's derived from the
+# astropy_helpers/MANIFEST.in, but requires additional includes for the actual
+# package directory and egg-info.
+
+include astropy_helpers/README.rst
+include astropy_helpers/CHANGES.rst
+include astropy_helpers/LICENSE.rst
+recursive-include astropy_helpers/licenses *
+
+include astropy_helpers/ez_setup.py
+include astropy_helpers/ah_bootstrap.py
+
+recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h
+recursive-include astropy_helpers/astropy_helpers.egg-info *
+# include the sphinx stuff with "*" because there are css/html/rst/etc.
+recursive-include astropy_helpers/astropy_helpers/sphinx *
+
+prune astropy_helpers/build
+prune astropy_helpers/astropy_helpers/tests
+
 
 global-exclude *.pyc *.o

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ else:
     import __builtin__ as builtins
 builtins._ASTROPY_SETUP_ = True
 
-from astropy_helpers.setup_helpers import (
-    register_commands, adjust_compiler, get_debug_option, get_package_info)
+from astropy_helpers.setup_helpers import (register_commands, get_debug_option,
+                                           get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -55,10 +55,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,


### PR DESCRIPTION
This contains two updates to the setup process:

- The changes from #144 to setup.py (removing adjust_compiler) - this replaces #144, which also updated the helpers (and since #144 was issued, they have been updated)
- Updates ``MANIFEST.in`` in the manner discussed more in astropy/astropy#4682 (and the addition in astropy/astropy@876961319e57974978d63b379522efdc0f32eb63).

cc @astrofrog @embray