### PR TITLE
Added placeholder for custom project logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,10 @@ release = package.__version__
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
+#html_logo = ''
+
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.


### PR DESCRIPTION
Added placeholder for users to add their own project logos to upper left corner on sidebar. This incantation is usually included in standard `conf.py` from `sphinx-quickstart` but somehow missing in the template.
