### PR TITLE
Replaced RTD domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ using this template to lay out the package.
 
 For more information, see:
 
-* `Detailed instructions for using this template <http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html>`_
+* `Detailed instructions for using this template <http://docs.astropy.org/en/latest/development/affiliated-packages.html>`_
 * `The Affiliated Packages section of the Astropy web site <http://affiliated.astropy.org>`_
 * `This template's Github code repository <https://github.com/astropy/package-template>`_
 


### PR DESCRIPTION
Replaced RTD domain with Astropy doc domain. I think this is better than just switching RTD domain from `.org` to `.io`. Similar to astropy/astropy#4835.

p.s. In case you are curious, I also quickly combed through `astropy-helpers` but didn't find anything to change in regards to this.