### PR TITLE
Updated Numpy versions on Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,13 +76,13 @@ matrix:
 
         # Try older numpy versions
         - python: 2.7
+          env: NUMPY_VERSION=1.10
+        - python: 2.7
           env: NUMPY_VERSION=1.9
         - python: 2.7
           env: NUMPY_VERSION=1.8
         - python: 2.7
           env: NUMPY_VERSION=1.7
-        - python: 2.7
-          env: NUMPY_VERSION=1.6
 
         # Try numpy pre-release
         - python: 3.5


### PR DESCRIPTION
Numpy stable is now 1.11. Dropped 1.6 and moved 1.10 to old.

This is to be consistent with astropy/astropy#4784 .