### PR TITLE
Updated Python 2 Appveyor test to use 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,16 @@ environment:
 
   matrix:
 
-      # We test Python 2.6 and 3.4 because 2.6 is most likely to have issues in
-      # Python 2 (if 2.6 passes, 2.7 virtually always passes) and Python 3.4 is
-      # the latest Python 3 release.
+      # We test Python 2.7 and 3.5 because 2.7 is the supported Python 2
+      # release and Python 3.5 is the latest Python 3 release.
 
-      - PYTHON_VERSION: "2.6"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9.1"
+      - PYTHON_VERSION: "2.7"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.4"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9.1"
+      - PYTHON_VERSION: "3.5"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
 platform:
     -x64
@@ -42,5 +41,4 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python setup.py test"
-
+    - "%CMD_IN_ENV% python setup.py test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   matrix:
 
       # We test Python 2.7 and 3.5 because 2.7 is the supported Python 2
-      # release and Python 3.5 is the latest Python 3 release.
+      # release of Astropy and Python 3.5 is the latest Python 3 release.
 
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"


### PR DESCRIPTION
Updated Python 2 Appveyor test to use 2.7 instead of 2.6. Also now use stable versions of Astropy and Numpy.

This is to be consistent with astropy/astropy#4450, which will be in 1.2 release. After the release, any Appveyor test using stable version of Astropy will complain about Python 2.6.