### PR TITLE
Fix configparser in new python 3.5 [#169]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This is how I fixed the configparser problem in naima.

Fixes #169 