### PR TITLE
Configparser fix import in docs/conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 htmlcov
 .coverage
 MANIFEST
+.ipynb_checkpoints
 
 # Sphinx
 docs/api

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,12 @@ except ImportError:
 from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
+
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This is to close #179.

Also updating helpers to 1.2 and minor gitignore addition.