### PR TITLE
Adding package name customization template for the docs page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,8 @@ release = package.__version__
 # variables set in the global configuration. The variables set in the
 # global configuration are listed below, commented out.
 
+
+# Please update these texts to match the name of your package.
 html_theme_options = {
     'logotext1': 'package',  # white,  semi-bold
     'logotext2': '-template',  # orange, light

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,12 @@ release = package.__version__
 # variables set in the global configuration. The variables set in the
 # global configuration are listed below, commented out.
 
+html_theme_options = {
+    'logotext1': 'package',  # white,  semi-bold
+    'logotext2': '-template',  # orange, light
+    'logotext3': ':docs'   # white,  light
+    }
+
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.
 #html_theme_path = []


### PR DESCRIPTION
This may be also useful to include in the template, so there is no need to dig around for the howto in the config of other packages.