### PR TITLE
Removed Python 2.6 in travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,14 +68,11 @@ matrix:
         - python: 3.5
           env: ASTROPY_VERSION=lts
 
-        # Python 2.6 and 3.3 doesn't have numpy 1.10 in conda, they can be put
+        # Python 3.3 doesn't have numpy 1.10 in conda, but can be put
         # back into the main matrix once the numpy build is available in the
         # astropy-ci-extras channel (or in the one provided in the
         # CONDA_CHANNELS environmental variable).
-        - python: 2.6
-          env: SETUP_CMD='egg_info'
-        - python: 2.6
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9
+
         - python: 3.3
           env: SETUP_CMD='egg_info'
         - python: 3.3

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -5,6 +5,11 @@ be removed in affiliated packages.
 The changes below indicate what file the change was made in so that these can
 be copied over manually if desired.
 
+1.1.3 (unreleased)
+------------------
+
+- Removed Python 2.6 tests from travis.yml file as astropy 1.2 no longer supports Python 2.6 [#]
+
 1.1.2 (2016-07-02)
 ------------------
 

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -8,7 +8,7 @@ be copied over manually if desired.
 1.1.3 (unreleased)
 ------------------
 
-- Removed Python 2.6 tests from travis.yml file as astropy 1.2 no longer supports Python 2.6 [#]
+- Removed Python 2.6 tests from travis.yml file as astropy 1.2 no longer supports Python 2.6 [#183]
 
 1.1.2 (2016-07-02)
 ------------------


### PR DESCRIPTION
Since Python 2.6 is no longer supported by astropy 1.2, the travis tests fail for python =2.6. We should either freeze the astropy version to 1.1 here or we should remove python 2.6 from the default travis matrix. I have opted for the latter as that seems the most consistent with the astropy core development.