### PR TITLE
Add a section for build_docs so it builds to the same path as build_s…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,11 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
+[build_docs]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1


### PR DESCRIPTION
Same as astropy/astropy#5156

This adds a new section to `setup.cfg` for `build_docs` so that

    python setup.py build_sphinx

and

    python setup.py build_docs

build to the same location: `<root>/docs/_build/...`. 

cc @eteq @astrofrog 