### PR TITLE
Switching to conda install in the RTD config templates

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,0 +1,12 @@
+name: package-template
+
+channels:
+    - astropy
+
+dependencies:
+    - astropy
+    - Cython
+    - matplotlib
+    - numpy
+#   - pip:
+#       - dependency_from_pip

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,5 +1,4 @@
 numpy
 matplotlib
 Cython
-astropy-helpers
 astropy

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,0 @@
-numpy
-matplotlib
-Cython
-astropy

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+conda:
+  file: .rtd-environment.yml
+
+python:
+   setup_py_install: true


### PR DESCRIPTION
The dependency on astropy-helpers with the current infrastructure is done as a git submodule and not as a separate package, so no need to list it as a package dependency, I think.