### PR TITLE
Adding template for usage of CONDA_CHANNELS in CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,13 @@ env:
         # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython'
 
+        # Conda packages for affiliated packages are hosted in channel
+        # "astropy" while builds for astropy LTS with recent numpy versions
+        # are in astropy-ci-extras. If your package uses either of these,
+        # add the channels to CONDA_CHANNELS along with any other channels
+        # you want to use.
+        # - CONDA_CHANNELS='astopy-ci-extras astropy'
+
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.
         # - SETUP_XVFB=True

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,18 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
+
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
       CONDA_DEPENDENCIES: "Cython"
+
+      # Conda packages for affiliated packages are hosted in channel
+      # "astropy" while builds for astropy LTS with recent numpy versions
+      # are in astropy-ci-extras. If your package uses either of these,
+      # add the channels to CONDA_CHANNELS along with any other channels
+      # you want to use.
+      # CONDA_CHANNELS: "astopy-ci-extras astropy"
 
   matrix:
 


### PR DESCRIPTION
We plan to remove the default addition of channels (https://github.com/astropy/ci-helpers/pull/119 and https://github.com/astropy/ci-helpers/pull/128), so packages should explicitly set the channels they need to use.