### PR TITLE
Removing deprecated build_sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
+          env: SETUP_CMD='build_docs -w'
 
         # Try Astropy development version
         - python: 2.7


### PR DESCRIPTION
The docs build in `.travis.yml` is being triggered like so:

```
        # Check for sphinx doc build warnings - we do this first because it
        # may run for a long time
        - python: 2.7
          env: SETUP_CMD='build_sphinx -w'
```

but the `build_sphinx` command has been deprecated by astropy/astropy#5179. Here I correct update to the new `build_docs` command.
