### PR TITLE
PEP386 is superseded by PEP440

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ license = BSD
 url = http://astropy.org/
 edit_on_github = False
 github_project = astropy/astropy
-# version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
+# version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 version = 0.0.dev
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 # to get from other parts of the setup infrastructure
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
-# VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
+# VERSION should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
 VERSION = metadata.get('version', '0.0.dev')
 
 # Indicates if this version is a release version


### PR DESCRIPTION
PEP386 is superseded by PEP440, so updated setup scripts to reflect this change.