### PR TITLE
Add a test data dir and root path

### DIFF
--- a/packagename/data/README.rst
+++ b/packagename/data/README.rst
@@ -5,3 +5,8 @@ This directory contains data files included with the affiliated package source
 code distribution. Note that this is intended only for relatively small files
 - large files should be externally hosted and downloaded as needed.
 
+The ``test`` directory can be used to store files needed for tests, the path to
+the directory is generated programatically in ``data/test/__init__.py`` so the
+correct path to the data can always be obtained with the ``from
+packagename.data.test import rootdir`` import.
+

--- a/packagename/data/test/__init__.py
+++ b/packagename/data/test/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+import os
+import glob
+
+import packagename
+
+__all__ = ["rootdir", "file_list"]
+
+# rootdir is the path to this folder
+rootdir = os.path.join(os.path.dirname(sunpy.__file__), "data", "test")
+
+# List of all files in the test directory excluding python files
+file_list = glob.glob(os.path.join(rootdir, '*.[!p]*'))


### PR DESCRIPTION
The idea here is to make it easy to use small test files in tests, i.e. always get the right path. We use this machinery in SunPy.