### PR TITLE
Fix lts builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
         # are in astropy-ci-extras. If your package uses either of these,
         # add the channels to CONDA_CHANNELS along with any other channels
         # you want to use.
-        # - CONDA_CHANNELS='astopy-ci-extras astropy'
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      # CONDA_CHANNELS: "astopy-ci-extras astropy"
+      CONDA_CHANNELS: "astropy-ci-extras astropy"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      CONDA_CHANNELS: "astropy-ci-extras astropy"
+      # CONDA_CHANNELS: "astropy-ci-extras astropy"
 
   matrix:
 


### PR DESCRIPTION
I've picked @bmorris3's commits from #199 that are adding ``astropy-ci-extras`` to the conda channels. We need that channel to pick up the astropy LTS version from as it's not built any more on the default channel.