### PR TITLE
Adding python 3.6 for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false


### PR DESCRIPTION
We should add python 3.6 to the template CI files once it's available via conda.