### PR TITLE
Use long_description if it's set in setup.cfg 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,13 @@ URL = metadata.get('url', 'http://astropy.org')
 #   (1) set in setup.cfg,
 #   (2) load README.rst,
 #   (3) package docstring
+readme_glob = 'README*'
 _cfg_long_description = metadata.get('long_description', '')
 if _cfg_long_description:
     LONG_DESCRIPTION = _cfg_long_description
 
-elif os.path.exists('README.rst'):
-    with open('README.rst') as f:
+elif len(glob.glob(readme_glob)) > 0:
+    with open(glob.glob(readme_glob)[0]) as f:
         LONG_DESCRIPTION = f.read()
 
 else:
@@ -77,9 +78,9 @@ cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
 generate_version_py(PACKAGENAME, VERSION, RELEASE,
                     get_debug_option(PACKAGENAME))
 
-# Treat everything in scripts except README.rst as a script to be installed
+# Treat everything in scripts except README* as a script to be installed
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
-           if os.path.basename(fname) != 'README.rst']
+           if not os.path.basename(fname).startswith('README')]
 
 
 # Get configuration information from all of the various subpackages.

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,23 @@ AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', 'http://astropy.org')
 
-# Get the long description from the package's docstring
-__import__(PACKAGENAME)
-package = sys.modules[PACKAGENAME]
-LONG_DESCRIPTION = package.__doc__
+# order of priority for long_description:
+#   (1) set in setup.cfg,
+#   (2) load README.rst,
+#   (3) package docstring
+_cfg_long_description = metadata.get('long_description', '')
+if _cfg_long_description:
+    LONG_DESCRIPTION = _cfg_long_description
+
+elif os.path.exists('README.rst'):
+    with open('README.rst') as f:
+        LONG_DESCRIPTION = f.read()
+
+else:
+    # Get the long description from the package's docstring
+    __import__(PACKAGENAME)
+    package = sys.modules[PACKAGENAME]
+    LONG_DESCRIPTION = package.__doc__
 
 # Store the package name in a built-in variable so it's easy
 # to get from other parts of the setup infrastructure

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,17 @@ URL = metadata.get('url', 'http://astropy.org')
 
 # order of priority for long_description:
 #   (1) set in setup.cfg,
-#   (2) load README.rst,
-#   (3) package docstring
+#   (2) load LONG_DESCRIPTION.rst,
+#   (3) load README.rst,
+#   (4) package docstring
 readme_glob = 'README*'
 _cfg_long_description = metadata.get('long_description', '')
 if _cfg_long_description:
     LONG_DESCRIPTION = _cfg_long_description
+
+elif os.path.exists('LONG_DESCRIPTION.rst'):
+    with open('LONG_DESCRIPTION.rst') as f:
+        LONG_DESCRIPTION = f.read()
 
 elif len(glob.glob(readme_glob)) > 0:
     with open(glob.glob(readme_glob)[0]) as f:


### PR DESCRIPTION
I ran in to the same issue as described in #194 so I implemented the following set of places to check to set the `long_description` kwarg in `setup()` (in order of priority):

1. read from `setup.cfg`
2. load full text from `README.rst`
3. use the package docstring
