### PR TITLE
Refactoring travis matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: c
 
 os:
     - linux
-    - osx
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
 
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
+os:
+    - linux
+    - osx
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -27,11 +28,13 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - EVENT_TYPE='pull_request push'
 
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
@@ -51,9 +54,11 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
+        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 matrix:
 
@@ -61,58 +66,60 @@ matrix:
     fast_finish: true
 
     include:
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+        # Do a coverage test.
+        - os: linux
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 2.7
+        - os: linux
           env: SETUP_CMD='build_docs -w'
 
-        # Try Astropy development version
-        - python: 2.7
+        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        - os: linux
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
           env: ASTROPY_VERSION=development
-        - python: 3.5
-          env: ASTROPY_VERSION=development
-        - python: 2.7
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+        - os: linux
           env: ASTROPY_VERSION=lts
-        - python: 3.5
-          env: ASTROPY_VERSION=lts
 
-        # Python 3.3 doesn't have numpy 1.10 in conda, but can be put
-        # back into the main matrix once the numpy build is available in the
-        # astropy-ci-extras channel (or in the one provided in the
-        # CONDA_CHANNELS environmental variable).
+        # Try all python versions and Numpy versions. Since we can assume that
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
+        # time.
 
-        - python: 3.3
-          env: SETUP_CMD='egg_info'
-        - python: 3.3
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9
-
-        # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.10
-        - python: 2.7
-          env: NUMPY_VERSION=1.9
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+        - os: linux
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
+        - os: linux
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+        - os: linux
+          env: NUMPY_VERSION=1.11
 
         # Try numpy pre-release
-        - python: 3.5
+        - os: linux
           env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
 
         # Do a PEP8 test with pycodestyle
-        - python: 3.5
+        - os: linux
           env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
 
     allow_failures:
         # Do a PEP8 test with pycodestyle
         # (allow to fail unless your code completely compliant)
-        - python: 3.5
+        - os: linux
           env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,14 +25,14 @@ environment:
 
   matrix:
 
-      # We test Python 2.7 and 3.5 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.5 is the latest Python 3 release.
+      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
+      # release of Astropy and Python 3.6 is the latest Python 3 release.
 
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 


### PR DESCRIPTION
This PR contains several changes to the matrix, so packages can start with a bit more optimal version:

* include an osx build
* default python version is 3.6 (updated in appveyor, too)
* reduce the number of builds for older python/numpy versions, build only one of each
* add numpy 1.11 to the old versions as 1.12 is out as new stable
* add EVENT_TYPE to control with builds to run for the cron jobs

closes #214
