### PR TITLE
Use timeout to make sure egg_info builds don't run for too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,12 @@ matrix:
         - python: 3.5
           env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
 
+before_install:
+    - if [[ $TRAVIS_OS_NAME == osx ]]; then
+          shopt -s expand_aliases;
+          alias timeout='gtimeout';
+      fi
+
 install:
 
     # We now use the ci-helpers package to set up our testing environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - TIMEOUT=3600
 
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
@@ -51,7 +52,7 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
+        - SETUP_CMD='egg_info' TIMEOUT=30
         # Try all python versions with the latest numpy
         - SETUP_CMD='test'
 
@@ -141,7 +142,7 @@ install:
     # other dependencies.
 
 script:
-   - $MAIN_CMD $SETUP_CMD
+   - timeout $TIMEOUT $MAIN_CMD $SETUP_CMD;
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line


### PR DESCRIPTION
This supersedes #138.
Currently we don't have osx builds here (will change with #217), but the concept here was tested and is working on OSX (tests runs were on my fork here: https://travis-ci.org/bsipocz/package-template/builds/193396839)

I think it's cleaner if the timeout vs gtimeout alias is set upstream in ``ci-helpers``, but interested in hearing opinions (@astrofrog?) before doing it that way.