### PR TITLE
Fix PEP8 for _astropy_init.py

### DIFF
--- a/packagename/_astropy_init.py
+++ b/packagename/_astropy_init.py
@@ -22,11 +22,13 @@ try:
 except ImportError:
     __githash__ = ''
 
+
 # set up the test command
 def _get_test_runner():
     import os
     from astropy.tests.helper import TestRunner
     return TestRunner(os.path.dirname(__file__))
+
 
 def test(package=None, test_path=None, args=None, plugins=None,
          verbose=False, pastebin=None, remote_data=False, pep8=False,
@@ -110,10 +112,13 @@ def test(package=None, test_path=None, args=None, plugins=None,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
 
-if not _ASTROPY_SETUP_:
+if not _ASTROPY_SETUP_:  # noqa
     import os
     from warnings import warn
-    from astropy import config
+    from astropy.config.configuration import (
+        update_default_config,
+        ConfigurationDefaultMissingError,
+        ConfigurationDefaultMissingWarning)
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
@@ -123,16 +128,16 @@ if not _ASTROPY_SETUP_:
         config_template = os.path.join(config_dir, __package__ + ".cfg")
         if os.path.isfile(config_template):
             try:
-                config.configuration.update_default_config(
+                update_default_config(
                     __package__, config_dir, version=__version__)
             except TypeError as orig_error:
                 try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
+                    update_default_config(__package__, config_dir)
+                except ConfigurationDefaultMissingError as e:
+                    wmsg = (e.args[0] +
+                            " Cannot install default profile. If you are "
                             "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
+                    warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
-                except:
+                except Exception:
                     raise orig_error


### PR DESCRIPTION
Fix PEP8 for `_astropy_init.py`. My package using this template but with strict PEP8 checking switched on often complains about the many PEP8 errors in `_astropy_init.py`. This PR will make life a bit easier for others in similar situation.