### PR TITLE
Using more flexible string comparison for coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,4 +153,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi


### PR DESCRIPTION
 We do this to allow diversion from the template $SETUP_CMD, otherwise one can end up with issues like astropy/astropy#5701