### PR TITLE
Explicitly highlight docs as python 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,9 @@ setup_cfg = dict(conf.items('metadata'))
 
 # -- General configuration ----------------------------------------------------
 
+# By default, highlight as Python 3.
+highlight_language = 'python3'
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.2'
 


### PR DESCRIPTION
This is one way to fix the missing button that removes output in code blocks in docs (see https://github.com/astropy/astropy-helpers/pull/287 for the more general fix).

In my limited testing, it seems to work fine even if the docs are built with python 2.  If problems arise with python 2, one can set `highlight_language = 'python'`. 