### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,13 @@ For more information, see:
 * `This template's Github code repository <https://github.com/astropy/package-template>`_
 
 
-Using this package
-------------------
+Using this package template
+---------------------------
 
-This package makes use of the `cookiecutter
+Using cookiecutter
+^^^^^^^^^^^^^^^^^^
+
+This package template makes use of the `cookiecutter
 <https://cookiecutter.readthedocs.io/en/latest/index.html>`__ package to make it
 easier to get started with the package template. You will need to `install cookiecutter <https://cookiecutter.readthedocs.io/en/latest/installation.html>`__ which can
 be done easily using conda or pip::
@@ -37,8 +40,18 @@ Once you have cookiecutter installed you can run::
 
   cookiecutter gh:astropy/package-template
 
-
 Which will ask you a series of questions to configure your package.
+
+
+Manually
+^^^^^^^^
+
+The ``rendered`` git branch of this repository contains a version of the
+template populated with placeholders.  This allows the package template to be
+used directly without using cookiecutter, although a number of
+`manual steps  <http://docs.astropy.org/projects/package-template/en/latest/>`_
+are required.  For this reason the cookiecutter approach is recommended.
+
 
 
 Improving the package template

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,14 @@ Such packages can make use of the setup, installation, and documentation
 infrastructure developed for the ``astropy`` core package simply by
 using this template to lay out the package.
 
+For more information, see:
+
+* The `documentation for this package template itself  <http://docs.astropy.org/projects/package-template/en/latest/>`_
+* Astropy `documentation about this template <http://docs.astropy.org/en/latest/development/affiliated-packages.html>`_
+* `The Affiliated Packages section of the Astropy web site <http://affiliated.astropy.org>`_
+* `This template's Github code repository <https://github.com/astropy/package-template>`_
+
+
 Using this package
 ------------------
 
@@ -30,7 +38,7 @@ Once you have cookiecutter installed you can run::
   cookiecutter gh:astropy/package-template
 
 
-Which will ask you a series of questions to configure your package. For more information you can see the `package template documentation <http://docs.astropy.org/en/latest/development/affiliated-packages.html>`__.
+Which will ask you a series of questions to configure your package.
 
 
 Improving the package template

--- a/README.rst
+++ b/README.rst
@@ -30,15 +30,15 @@ Once you have cookiecutter installed you can run::
   cookiecutter gh:astropy/package-template
 
 
-Which will ask you a series of questions to configure your package. For more information you can see the `package template documentation <>`__.
+Which will ask you a series of questions to configure your package. For more information you can see the `package template documentation <http://docs.astropy.org/en/latest/development/affiliated-packages.html>`__.
 
 
 Improving the package template
 ------------------------------
 
-If you want to modify this package to add or fix things, the actual folder that
-the user ends up with is the ``{{ cookiecutter.package_name }}`` folder in this
+If you want to modify this package template to add or fix things, the folder that
+the user ends up with is ``{{ cookiecutter.package_name }}`` in this
 repository. Everything in the repository that is not in this folder is not part
 of the template that the user will have rendered.
 
-For further information on writing templates for cookiecutter see `the docs <https://cookiecutter.readthedocs.io/en/latest/first_steps.html>`__
+For further information on writing templates for cookiecutter see `the cookiecutter docs <https://cookiecutter.readthedocs.io/en/latest/first_steps.html>`__.


### PR DESCRIPTION
This makes some minor fixes to the new README on the cookiecutter branch.

@Cadair - one thing that was odd: I *think* you meant to link to the astropy affiliated package docs, right?  That's what I put in for the currently-broken link.  But that page looks like it hasn't been updated yet for the cookiecutter version?  Is that in the works?  This is *critical* to it being useful to users...