### PR TITLE
Setup cfg pytest settings

### DIFF
--- a/{{ cookiecutter.package_name }}/setup.cfg
+++ b/{{ cookiecutter.package_name }}/setup.cfg
@@ -12,8 +12,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
 addopts = -p no:warnings

--- a/{{ cookiecutter.package_name }}/setup.cfg
+++ b/{{ cookiecutter.package_name }}/setup.cfg
@@ -16,6 +16,7 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
+addopts = -p no:warnings
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
Changing the header as ``[pytest]`` has been deprecated since 2006 Aug, in pytest 3.0.

Also disable displaying warnings by default. It used to be the case, but in pytest 3.1 ``pytest-warnings`` got merged into core, and the behaviour changed.