### PR TITLE
Removing testing for astropy dev and py2.7

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -86,10 +86,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
+        # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'


### PR DESCRIPTION
This should partially address the fact that astropy dev has already remove python2 support. 