### PR TITLE
Change default astropy_helpers_version based on python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
       - EXTRA_CONTEXT='include_example_cython_code=y'
       - EXTRA_CONTEXT="package_name=AstropyProject" FOLDERNAME='AstropyProject'
       - EXTRA_CONTEXT='_parent_project=sunpy'
-      - EXTRA_CONTEXT='minimum_python_version="3.5"'
+      - EXTRA_CONTEXT='minimum_python_version=3.5'
       - TASK='render' EXTRA_CONTEXT='include_example_cython_code=y initialize_git_repo=n'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
       - EXTRA_CONTEXT='include_example_cython_code=y'
       - EXTRA_CONTEXT="package_name=AstropyProject" FOLDERNAME='AstropyProject'
       - EXTRA_CONTEXT='_parent_project=sunpy'
-      - EXTRA_CONTEXT='__minimum_python_version__="3.5"'
+      - EXTRA_CONTEXT='minimum_python_version="3.5"'
       - TASK='render' EXTRA_CONTEXT='include_example_cython_code=y initialize_git_repo=n'
 
 install:

--- a/QUESTIONS.rst
+++ b/QUESTIONS.rst
@@ -22,4 +22,5 @@ a description of each of the prompts.
 15. ``use_appveyor_ci``: If 'y' the template will include an example ``appveyor.yml`` file for the Appveyor CI service.
 16. ``use_read_the_docs``: If 'y' the ``read_the_docs.yml`` and ``.rtd-environment.yml`` files will be included for using conda on Read the Docs.
 17. ``sphinx_theme``: The value of the ``html_theme`` variable in the sphinx configuration file.
-18. ``__minimum_python_version__``: Version string of minimum supported Python version. For example, "3.5" or "2.7". Leave as "" to skip this check.
+18. ``support_python2``: If 'y' the template will include the Python 2 compatible ``astropy_helpers`` LTS version, otherwise it uses the latest one.
+19. ``__minimum_python_version__``: Version string of minimum supported Python version. For example, "3.5" or "2.7". Leave as "" to skip this check.

--- a/QUESTIONS.rst
+++ b/QUESTIONS.rst
@@ -23,4 +23,4 @@ a description of each of the prompts.
 16. ``use_read_the_docs``: If 'y' the ``read_the_docs.yml`` and ``.rtd-environment.yml`` files will be included for using conda on Read the Docs.
 17. ``sphinx_theme``: The value of the ``html_theme`` variable in the sphinx configuration file.
 18. ``support_python2``: If 'y' the template will include the Python 2 compatible ``astropy_helpers`` LTS version, otherwise it uses the latest one.
-19. ``__minimum_python_version__``: Version string of minimum supported Python version. For example, "3.5" or "2.7". Leave as "" to skip this check.
+19. ``minimum_python_version``: Version string of minimum supported Python version. For example, "3.5" or "2.7". Leave as "" to skip this check.

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -20,7 +20,7 @@ be copied over manually if desired.
 - Allow Python version check at installation and import time. [#302]
 
 - Adding ``support_python2`` option to distinguish with version of
-  astropy_helpers to be used. [#305]
+  astropy_helpers to be used. [#306]
 
 
 1.1.2 (2016-07-02)

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -19,6 +19,10 @@ be copied over manually if desired.
 
 - Allow Python version check at installation and import time. [#302]
 
+- Adding ``support_python2`` option to distinguish with version of
+  astropy_helpers to be used. [#305]
+
+
 1.1.2 (2016-07-02)
 ------------------
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,11 +18,12 @@
     "use_read_the_docs": "y",
     "sphinx_theme": "astropy-boostrap",
     "initialize_git_repo": "y",
-    "astropy_helpers_version": "v2.0.2",
     "_parent_project": "astropy",
     "_install_requires": "astropy",
     "_copy_without_render": [
         "docs/_templates"
     ],
+    "support_python2": "n",
+    "astropy_helpers_version": "{% if cookiecutter.support_python2 == 'y' %}v2.0.6{% else %}v3.0.1{% endif %}",
     "__minimum_python_version__": ""
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -25,5 +25,5 @@
     ],
     "support_python2": "n",
     "astropy_helpers_version": "{% if cookiecutter.support_python2 == 'y' %}v2.0.6{% else %}v3.0.1{% endif %}",
-    "__minimum_python_version__": ""
+    "minimum_python_version": "{% if cookiecutter.support_python2 == 'n'%}3.5{% endif %}"
 }

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -9,7 +9,7 @@ import sys
 # This is the same check as packagename/__init__.py but this one has to
 # happen before importing ah_bootstrap.
 {% if cookiecutter.minimum_python_version %}
-if sys.version_info < tuple((int(val) for val in {{ cookiecutter.minimum_python_version }}.split('.'))):
+if sys.version_info < tuple((int(val) for val in "{{ cookiecutter.minimum_python_version }}".split('.'))):
     sys.stderr.write("ERROR: {{ cookiecutter.module_name }} requires Python {} or later\n".format({{ cookiecutter.minimum_python_version }}))
     sys.exit(1)
 {% endif %}

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -8,9 +8,9 @@ import sys
 # Enforce Python version check during package import.
 # This is the same check as packagename/__init__.py but this one has to
 # happen before importing ah_bootstrap.
-{% if cookiecutter.__minimum_python_version__ %}
-if sys.version_info < tuple((int(val) for val in {{ cookiecutter.__minimum_python_version__ }}.split('.'))):
-    sys.stderr.write("ERROR: {{ cookiecutter.module_name }} requires Python {} or later\n".format({{ cookiecutter.__minimum_python_version__ }}))
+{% if cookiecutter.minimum_python_version %}
+if sys.version_info < tuple((int(val) for val in {{ cookiecutter.minimum_python_version }}.split('.'))):
+    sys.stderr.write("ERROR: {{ cookiecutter.module_name }} requires Python {} or later\n".format({{ cookiecutter.minimum_python_version }}))
     sys.exit(1)
 {% endif %}
 
@@ -145,8 +145,8 @@ setup(name=PACKAGENAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
-{% if cookiecutter.__minimum_python_version__ %}
-      python_requires='>={}'.format({{ cookiecutter.__minimum_python_version__ }}),
+{% if cookiecutter.minimum_python_version %}
+      python_requires='>={}'.format({{ cookiecutter.minimum_python_version }}),
 {% endif %}
       **package_info
 )

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
@@ -12,7 +12,7 @@ from ._{{ cookiecutter._parent_project }}_init import *
 import sys
 class UnsupportedPythonError(Exception):
     pass
-if sys.version_info < tuple((int(val) for val in {{ cookiecutter.minimum_python_version }}.split('.'))):
+if sys.version_info < tuple((int(val) for val in "{{ cookiecutter.minimum_python_version }}".split('.'))):
     raise UnsupportedPythonError("{{ cookiecutter.module_name }} does not support Python < {}".format({{ cookiecutter.minimum_python_version }}))
 {% endif %}
 

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
@@ -8,12 +8,12 @@ from ._{{ cookiecutter._parent_project }}_init import *
 
 # Enforce Python version check during package import.
 # This is the same check as the one at the top of setup.py
-{% if cookiecutter.__minimum_python_version__ %}
+{% if cookiecutter.minimum_python_version %}
 import sys
 class UnsupportedPythonError(Exception):
     pass
-if sys.version_info < tuple((int(val) for val in {{ cookiecutter.__minimum_python_version__ }}.split('.'))):
-    raise UnsupportedPythonError("{{ cookiecutter.module_name }} does not support Python < {}".format({{ cookiecutter.__minimum_python_version__ }}))
+if sys.version_info < tuple((int(val) for val in {{ cookiecutter.minimum_python_version }}.split('.'))):
+    raise UnsupportedPythonError("{{ cookiecutter.module_name }} does not support Python < {}".format({{ cookiecutter.minimum_python_version }}))
 {% endif %}
 
 if not _ASTROPY_SETUP_:


### PR DESCRIPTION
apparently cookiecutter understands jinja2 templates, so we can have conditionals in the json without too much extra hacking.

Close #303