### PR TITLE
Explicitly ask for minimum supported Python version

### DIFF
--- a/QUESTIONS.rst
+++ b/QUESTIONS.rst
@@ -22,5 +22,4 @@ a description of each of the prompts.
 15. ``use_appveyor_ci``: If 'y' the template will include an example ``appveyor.yml`` file for the Appveyor CI service.
 16. ``use_read_the_docs``: If 'y' the ``read_the_docs.yml`` and ``.rtd-environment.yml`` files will be included for using conda on Read the Docs.
 17. ``sphinx_theme``: The value of the ``html_theme`` variable in the sphinx configuration file.
-18. ``support_python2``: If 'y' the template will include the Python 2 compatible ``astropy_helpers`` LTS version, otherwise it uses the latest one.
-19. ``minimum_python_version``: Version string of minimum supported Python version. For example, "3.5" or "2.7". Leave as "" to skip this check.
+18. ``minimum_python_version``: Version string of minimum supported Python version

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -23,7 +23,6 @@
     "_copy_without_render": [
         "docs/_templates"
     ],
-    "support_python2": "n",
-    "astropy_helpers_version": "{% if cookiecutter.support_python2 == 'y' %}v2.0.6{% else %}v3.0.1{% endif %}",
-    "minimum_python_version": "{% if cookiecutter.support_python2 == 'n'%}3.5{% endif %}"
+    "minimum_python_version": ["2.7", "3.5", "3.6"],
+    "astropy_helpers_version": "{% if cookiecutter.minimum_python_version == '2.7' %}v2.0.6{% else %}v3.0.1{% endif %}"
 }

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -5,14 +5,11 @@ import glob
 import os
 import sys
 
-# Enforce Python version check during package import.
-# This is the same check as packagename/__init__.py but this one has to
-# happen before importing ah_bootstrap.
-{% if cookiecutter.minimum_python_version %}
+# Enforce Python version check - this is the same check as in __init__.py but
+# this one has to happen before importing ah_bootstrap.
 if sys.version_info < tuple((int(val) for val in "{{ cookiecutter.minimum_python_version }}".split('.'))):
     sys.stderr.write("ERROR: {{ cookiecutter.module_name }} requires Python {} or later\n".format({{ cookiecutter.minimum_python_version }}))
     sys.exit(1)
-{% endif %}
 
 import ah_bootstrap
 from setuptools import setup
@@ -145,8 +142,6 @@ setup(name=PACKAGENAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
-{% if cookiecutter.minimum_python_version %}
       python_requires='>={}'.format({{ cookiecutter.minimum_python_version }}),
-{% endif %}
       **package_info
 )

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/__init__.py
@@ -8,13 +8,13 @@ from ._{{ cookiecutter._parent_project }}_init import *
 
 # Enforce Python version check during package import.
 # This is the same check as the one at the top of setup.py
-{% if cookiecutter.minimum_python_version %}
 import sys
+
 class UnsupportedPythonError(Exception):
     pass
+
 if sys.version_info < tuple((int(val) for val in "{{ cookiecutter.minimum_python_version }}".split('.'))):
     raise UnsupportedPythonError("{{ cookiecutter.module_name }} does not support Python < {}".format({{ cookiecutter.minimum_python_version }}))
-{% endif %}
 
 if not _ASTROPY_SETUP_:
     # For egg_info test builds to pass, put package imports here.


### PR DESCRIPTION
I think we should just do this and then always define e.g. ``python_requires`` and do the checks for good practice. With the choice variable, this looks like:

```
Select minimum_python_version:
1 - 2.7
2 - 3.5
3 - 3.6
Choose from 1, 2, 3 [1]: 2
```