### PR TITLE
Fix boostrap -> bootstrap

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,7 +16,7 @@
     "use_travis_ci": "y",
     "use_appveyor_ci": "y",
     "use_read_the_docs": "y",
-    "sphinx_theme": "astropy-boostrap",
+    "sphinx_theme": "astropy-bootstrap",
     "initialize_git_repo": "y",
     "_parent_project": "astropy",
     "_install_requires": "astropy",

--- a/rendered.yml
+++ b/rendered.yml
@@ -16,6 +16,6 @@ default_context:
   use_travis_ci: "y"
   use_appveyor_ci: "y"
   use_read_the_docs: "y"
-  sphinx_theme: "astropy-boostrap"
+  sphinx_theme: "astropy-bootstrap"
   initialize_git_repo: "n"
   minimum_python_version: "2.7"

--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -112,7 +112,7 @@ release = package.__version__
 # name of a builtin theme or the name of a custom theme in html_theme_path.
 #html_theme = None
 
-{% if cookiecutter.sphinx_theme == "astropy-boostrap" %}
+{% if cookiecutter.sphinx_theme == "astropy-bootstrap" %}
 # Please update these texts to match the name of your package.
 html_theme_options = {
     'logotext1': 'package',  # white,  semi-bold


### PR DESCRIPTION
When setting up a new project via ``cookiecutter``, I was presented with ``astropy-boostrap`` as a default theme. This PR adds the ``t`` to the places it was missing.