### PR TITLE
Use package name logotext

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -109,7 +109,7 @@ release = package.__version__
 {% if cookiecutter.sphinx_theme == "astropy-bootstrap" %}
 html_theme_options = {
     'logotext1': '{{ cookiecutter.package_name }}',  # white,  semi-bold
-    'logotext2': 'lookinconfdotpy',  # orange, light
+    'logotext2': '',  # orange, light
     'logotext3': ':docs'   # white,  light
     }
 {% else %}

--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -107,10 +107,9 @@ release = package.__version__
 #html_theme = None
 
 {% if cookiecutter.sphinx_theme == "astropy-bootstrap" %}
-# Please update these texts to match the name of your package.
 html_theme_options = {
-    'logotext1': 'package',  # white,  semi-bold
-    'logotext2': '-template',  # orange, light
+    'logotext1': '{{ cookiecutter.package_name }}',  # white,  semi-bold
+    'logotext2': 'lookinconfdotpy',  # orange, light
     'logotext3': ':docs'   # white,  light
     }
 {% else %}


### PR DESCRIPTION
This is an attempt to address a confusion revealed by #331 - @simontorres pointed out that the header of the docs defaults right now to "package template".  In cookiecutter that's an option you can modify in `conf.py`... *but* it's probably not obvious you should do that manually given that the cookiecutter version does everything else automatically. So this PR automatically fills in the package name, and thereby cloes #331.

Implicitly this PR is two options though.  The first is obtained by dropping the second commit, and looks like this:
![image](https://user-images.githubusercontent.com/346587/40524818-be5dfb6c-5faa-11e8-9ee9-8b703dba0e3c.png)

("packagename" will be replaced by the actual package name").  That's a slightly cheeky poke to the package author to look in the conf.py.  The thinking here is that it's really hard to know where the author wants to put the "white vs orange" separation.

Option 2, which looks like:
![image](https://user-images.githubusercontent.com/346587/40524823-c5dc4132-5faa-11e8-9c30-952eab6ffadc.png)

That automatically gives something reasonable, but probably most users won't even realize they have an option to have some of the text by orange.

There's also an option 3 I could go with, to be like option 2 but all-orange instead of all-white.

Which do others prefer?  (especially @simontorres and @bsipocz as participants of #331)