### PR TITLE
import the test runner from runner

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
@@ -32,7 +32,7 @@ if not _ASTROPY_SETUP_:  # noqa
         ConfigurationDefaultMissingWarning)
 
     # Create the test function for self test
-    from astropy.tests.helper import TestRunner
+    from astropy.tests.runner import TestRunner
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
     __all__ += ['test']
 


### PR DESCRIPTION
This delays the import of pytest until the test command is actually run. fixes #341 

@lpsinger 