### PR TITLE
DOC: Add inclusively focused language and links to the template

### DIFF
--- a/{{ cookiecutter.package_name }}/README.rst
+++ b/{{ cookiecutter.package_name }}/README.rst
@@ -16,3 +16,36 @@ the terms of the {{ cookiecutter.license }} license. This package is based upon
 the `Astropy package template <https://github.com/astropy/package-template>`_
 which is licensed under the BSD 3-clause licence. See the licenses folder for
 more information.
+
+
+Contributing
+------------
+
+We love contributions! {{ cookiecutter.package_name }} is open source, built on open source, and we'd love
+to have you hang out in our community.
+
+**Imposter syndrome disclaimer**: We want your help. No, really.
+
+There may be a little voice inside your head that is telling you that you're not
+ready to be an open source contributor; that your skills aren't nearly good
+enough to contribute. What could you possibly offer a project like this one?
+
+We assure you - the little voice in your head is wrong. If you can write code at
+all, you can contribute code to open source. Contributing to open source
+projects is a fantastic way to advance one's coding skills. Writing perfect code
+isn't the measure of a good developer (that would disqualify all of us!); it's
+trying to create something, making mistakes, and learning from thoseF
+mistakes. That's how we all improve, and we are happy to help others learn.
+
+Being an open source contributor doesn't just mean writing code, either. You can
+help out by writing documentation, tests, or even giving feedback about the
+project (and yes - that includes giving feedback about the contribution
+process). Some of these contributions may be the most valuable to the project as
+a whole, because you're coming to the project with fresh eyes, so you can see
+the errors and assumptions that seasoned contributors have glossed over.
+
+(This disclaimer was originally written by
+[Adrienne Lowe](https://github.com/adriennefriend) for a
+[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted by
+{{ cookiecutter.package_name }} based on its use in the README file for the
+[MetPy project](https://github.com/Unidata/MetPy))

--- a/{{ cookiecutter.package_name }}/README.rst
+++ b/{{ cookiecutter.package_name }}/README.rst
@@ -34,7 +34,7 @@ We assure you - the little voice in your head is wrong. If you can write code at
 all, you can contribute code to open source. Contributing to open source
 projects is a fantastic way to advance one's coding skills. Writing perfect code
 isn't the measure of a good developer (that would disqualify all of us!); it's
-trying to create something, making mistakes, and learning from thoseF
+trying to create something, making mistakes, and learning from those
 mistakes. That's how we all improve, and we are happy to help others learn.
 
 Being an open source contributor doesn't just mean writing code, either. You can
@@ -48,4 +48,4 @@ the errors and assumptions that seasoned contributors have glossed over.
 `Adrienne Lowe <https://github.com/adriennefriend>`_ for a
 `PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
 {{ cookiecutter.package_name }} based on its use in the README file for the
-`MetPy project <https://github.com/Unidata/MetPy>`_)
+`MetPy project <https://github.com/Unidata/MetPy>`_.)

--- a/{{ cookiecutter.package_name }}/README.rst
+++ b/{{ cookiecutter.package_name }}/README.rst
@@ -44,8 +44,8 @@ process). Some of these contributions may be the most valuable to the project as
 a whole, because you're coming to the project with fresh eyes, so you can see
 the errors and assumptions that seasoned contributors have glossed over.
 
-(This disclaimer was originally written by
+*This disclaimer was originally written by
 `Adrienne Lowe <https://github.com/adriennefriend>`_ for a
 `PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
 {{ cookiecutter.package_name }} based on its use in the README file for the
-`MetPy project <https://github.com/Unidata/MetPy>`_.)
+`MetPy project <https://github.com/Unidata/MetPy>`_.*

--- a/{{ cookiecutter.package_name }}/README.rst
+++ b/{{ cookiecutter.package_name }}/README.rst
@@ -21,8 +21,8 @@ more information.
 Contributing
 ------------
 
-We love contributions! {{ cookiecutter.package_name }} is open source, built on open source, and we'd love
-to have you hang out in our community.
+We love contributions! {{ cookiecutter.package_name }} is open source,
+built on open source, and we'd love to have you hang out in our community.
 
 **Imposter syndrome disclaimer**: We want your help. No, really.
 
@@ -45,7 +45,7 @@ a whole, because you're coming to the project with fresh eyes, so you can see
 the errors and assumptions that seasoned contributors have glossed over.
 
 (This disclaimer was originally written by
-[Adrienne Lowe](https://github.com/adriennefriend) for a
-[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted by
+`Adrienne Lowe <https://github.com/adriennefriend>`_ for a
+`PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
 {{ cookiecutter.package_name }} based on its use in the README file for the
-[MetPy project](https://github.com/Unidata/MetPy))
+`MetPy project <https://github.com/Unidata/MetPy>`_)


### PR DESCRIPTION
Fix #349

Once, we hash things out here, we should then discuss about including it (or not) in Astropy core and other existing affiliated packages.

cc @Cadair , @mwcraig , @bsipocz , and @astropy/coordinators 

Background: This stemmed from diversity discussions at Scipy 2018 and was given permission by Nathan Goldbaum from `yt` to share.