### PR TITLE
TST: Bump numpy versions in Travis CI

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -110,11 +110,11 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13
         - os: linux
-          env: NUMPY_VERSION=1.12
+          env: NUMPY_VERSION=1.14
 
         # Try numpy pre-release
         - os: linux


### PR DESCRIPTION
Numpy 1.15 is out now, so...