### PR TITLE
TST: Test Python 3.7 on Appveyor

### DIFF
--- a/{{ cookiecutter.package_name }}/appveyor.yml
+++ b/{{ cookiecutter.package_name }}/appveyor.yml
@@ -38,8 +38,8 @@ environment:
         NUMPY_VERSION: "stable"
       {%- endif %}
 
-      # We test Python 3.6 for Python 3 support.
-      - PYTHON_VERSION: "3.6"
+      # We test Python 3.7 for Python 3 support.
+      - PYTHON_VERSION: "3.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 


### PR DESCRIPTION
This might be a bit more controversial... Address #354 but for Windows.