### PR TITLE
Include minimum Python version in RTD configuration

### DIFF
--- a/{{ cookiecutter.package_name }}/.rtd-environment.yml
+++ b/{{ cookiecutter.package_name }}/.rtd-environment.yml
@@ -4,6 +4,7 @@ channels:
     - astropy
 
 dependencies:
+    - python>={{ cookiecutter.minimum_python_version }}
     - astropy
     - Cython
     - matplotlib


### PR DESCRIPTION
Fixes https://github.com/astropy/package-template/issues/334 (I think)