### PR TITLE
Improve consistency for PIP_DEPENDENCIES and CONDA_CHANNELS

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -32,7 +32,6 @@ env:
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES=''
         - EVENT_TYPE='pull_request push'
 
         {% if cookiecutter.include_example_cython_code == 'y' %}
@@ -42,14 +41,14 @@ env:
         - CONDA_DEPENDENCIES='Cython'
         - CONDA_DEPENDENCIES_DOC='Cython sphinx-astropy'
         {% else %}
-        # List other runtime dependencies for the package that are available as
-        # conda packages here.
+        # List runtime dependencies for the package that are available as conda
+        # packages here.
         - CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES_DOC='sphinx-astropy'
         {% endif %}
         # List other runtime dependencies for the package that are available as
         # pip packages here.
-        # - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES=''
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions

--- a/{{ cookiecutter.package_name }}/appveyor.yml
+++ b/{{ cookiecutter.package_name }}/appveyor.yml
@@ -30,7 +30,7 @@ environment:
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      # CONDA_CHANNELS: "astropy-ci-extras astropy"
+      CONDA_CHANNELS: "astropy-ci-extras astropy"
 
   matrix:
 

--- a/{{ cookiecutter.package_name }}/appveyor.yml
+++ b/{{ cookiecutter.package_name }}/appveyor.yml
@@ -17,10 +17,13 @@ environment:
       # Cython code, you can set CONDA_DEPENDENCIES: ""
       CONDA_DEPENDENCIES: "Cython"
       {% else %}
-      # List other runtime dependencies for the package that are available as
-      # conda packages here.
+      # List runtime dependencies for the package that are available as conda
+      # packages here.
       CONDA_DEPENDENCIES: ""
       {% endif %}
+      # List other runtime dependencies for the package that are available as
+      # pip packages here.
+      PIP_DEPENDENCIES: ""
 
       # Conda packages for affiliated packages are hosted in channel
       # "astropy" while builds for astropy LTS with recent numpy versions


### PR DESCRIPTION
There was a duplicate PIP_DEPENDENCIES section in the Travis file and none in AppVeyor