### PR TITLE
Added sphinx-astropy as an RTD dependency

### DIFF
--- a/{{ cookiecutter.package_name }}/.rtd-environment.yml
+++ b/{{ cookiecutter.package_name }}/.rtd-environment.yml
@@ -9,5 +9,6 @@ dependencies:
     - Cython
     - matplotlib
     - numpy
+    - sphinx-astropy
 #   - pip:
 #       - dependency_from_pip


### PR DESCRIPTION
I think this was an oversight - in this case the docs are built with ``make html`` so this is needed even with the latest astropy-helpers.