### PR TITLE
Make setup.py valid on Python 2 always for error printing reasons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ env:
       - EXTRA_CONTEXT="package_name=AstropyProject" FOLDERNAME='AstropyProject'
       - EXTRA_CONTEXT='_parent_project=sunpy'
       - EXTRA_CONTEXT='minimum_python_version=3.5'
+      - PYTHON_VERSION=2.7 TASK='error_check' EXTRA_CONTEXT='minimum_python_version=3.5'
       - TASK='render' FLAGS='--config-file rendered.yml --no-input' EXTRA_CONTEXT='include_example_cython_code=y initialize_git_repo=n license=Other'
+
 install:
 
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
@@ -48,6 +50,7 @@ script:
    - if [[ $TASK == 'test' ]]; then python setup.py build; fi
    - if [[ $TASK == 'test' ]]; then python setup.py build_docs; fi
    - if [[ $TASK == 'test' ]]; then python setup.py test; fi
+   - if [[ $TASK == 'error_check' ]]; then python setup.py egg_info 2>&1 | grep "ERROR:"; fi
 
 
 after_success:

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Note: This file needs to be Python 2 / <3.6 compatible, so that the nice
+# "This package only supports Python 3.x+" error prints without syntax errors etc.
 
 import glob
 import os

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -4,14 +4,10 @@
 import glob
 import os
 import sys
-{% if cookiecutter.minimum_python_version.startswith("2") %}
 try:
     from configparser import ConfigParser
 except ImportError:
     from ConfigParser import ConfigParser
-{%- else %}
-from configparser import ConfigParser
-{%- endif %}
 
 # Get some values from the setup.cfg
 conf = ConfigParser()


### PR DESCRIPTION
If you run setup.py on a package which doesn't support python 2 it should print the error saying it supports Python 3.x+ or whatever. For this to work we need to keep the setup.py file syntax compatible with all python versions for as long as we want this error to work.

Note: the file only has to be runtime compatible with Python 2 above the version check error!