### PR TITLE
Prevent pytest from picking up test function as a test

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
@@ -34,6 +34,7 @@ if not _ASTROPY_SETUP_:  # noqa
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+    test.__test__ = False
     __all__ += ['test']
 
     # add these here so we only need to cleanup the namespace at the end


### PR DESCRIPTION
This one-line change prevents pytest from picking up the test function as a test.
Works for me locally.
Fixes #372