### PR TITLE
Using explicit imports to fix pytest 3.7+ issue

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
@@ -4,8 +4,9 @@
 from astropy.version import version as astropy_version
 if astropy_version < '3.0':
     # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
+    # plugins themselves in order to make them discoverable by pytest. Use explicit
+    # import to avoid complications with newer pytest versions
+    from astropy.tests.pytest_plugins import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 else:
     # As of Astropy 3.0, the pytest plugins provided by Astropy are
     # automatically made available when Astropy is installed. This means it's


### PR DESCRIPTION
See details in https://github.com/astropy/astropy/issues/8177 and xrefs therein.