### PR TITLE
Make the minimum rendered version python 3.6

### DIFF
--- a/rendered.yml
+++ b/rendered.yml
@@ -18,4 +18,4 @@ default_context:
   use_read_the_docs: "y"
   sphinx_theme: "astropy-bootstrap"
   initialize_git_repo: "n"
-  minimum_python_version: "2.7"
+  minimum_python_version: "3.6"


### PR DESCRIPTION
Let's sunset python 2 here, too.

(we may want to create another rendered branch with python2 support, too).