### PR TITLE
Remove redundant Python version check

### DIFF
--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -24,14 +24,6 @@ LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', '{{ cookiecutter.project_url }}')
 __minimum_python_version__ = metadata.get("minimum_python_version", "{{ cookiecutter.minimum_python_version }}")
 
-# Enforce Python version check - this is the same check as in __init__.py but
-# this one has to happen before importing ah_bootstrap.
-if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    sys.stderr.write("ERROR: {{ cookiecutter.module_name }} requires Python {} or later\n".format(__minimum_python_version__))
-    sys.exit(1)
-
-# Import ah_bootstrap after the python version validation
-
 import ah_bootstrap
 from setuptools import setup
 {% if cookiecutter.minimum_python_version.startswith("2") %}


### PR DESCRIPTION
Last year we added a  Python version check at the top of ``setup.py`` to address https://github.com/astropy/astropy/issues/7306. However, since then this has also been added to the top of ``ah_bootstrap.py``. Since ``ah_bootstrap`` is imported immediately after the check, we can therefore remove the check in ``setup.py``.

*(this is part of a series of PRs to simplify setup.py)*

Companion to https://github.com/astropy/astropy/pull/8344