### PR TITLE
Python version specific builtins import

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/_{{ cookiecutter._parent_project }}_init.py
@@ -6,11 +6,15 @@ __all__ = ['__version__', '__githash__']
 try:
     _ASTROPY_SETUP_
 except NameError:
+{% if cookiecutter.minimum_python_version.startswith("2") %}
     from sys import version_info
     if version_info[0] >= 3:
         import builtins
     else:
         import __builtin__ as builtins
+{%- else %}
+    import builtins
+{%- endif %}
     builtins._ASTROPY_SETUP_ = False
 
 try:


### PR DESCRIPTION
Same as https://github.com/astropy/package-template/blob/bb16467e562b52d5a0baffdc7e36de6882e42e1d/%7B%7B%20cookiecutter.package_name%20%7D%7D/setup.py#L37-L45 

I noticed this when I was removing PY2 support for my package and copied this file over from the template and found myself have to do this extra editing by hand.