### PR TITLE
Adding ah_bootstrap even when the repo is not initailized

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import urllib.request
 
 
 def remove_file(filepath):
@@ -86,3 +87,10 @@ if __name__ == '__main__':
             print(
                 "gitpython is not installed so the repository will not be initialised "
                 "and astropy_helpers not downloaded.")
+
+    else:
+        with urllib.request.urlopen(
+                'https://raw.githubusercontent.com/astropy/astropy-helpers/'
+                '{{ cookiecutter.astropy_helpers_version }}/ah_bootstrap.py') as ah:
+            with open('ah_bootstrap.py', mode='wb') as ah_file:
+                shutil.copyfileobj(ah, ah_file)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -89,8 +89,8 @@ if __name__ == '__main__':
                 "and astropy_helpers not downloaded.")
 
     else:
-        with urllib.request.urlopen(
-                'https://raw.githubusercontent.com/astropy/astropy-helpers/'
-                '{{ cookiecutter.astropy_helpers_version }}/ah_bootstrap.py') as ah:
-            with open('ah_bootstrap.py', mode='wb') as ah_file:
-                shutil.copyfileobj(ah, ah_file)
+        urllib.request.urlretrieve(
+            url=('https://raw.githubusercontent.com/astropy/astropy-helpers/'
+                 '{{ cookiecutter.astropy_helpers_version }}/ah_bootstrap.py'),
+            filename='ah_bootstrap.py')
+        urllib.request.urlcleanup()


### PR DESCRIPTION
This is to fix https://github.com/astropy/package-template/issues/407

This also fixes https://github.com/astropy/package-template/issues/304

After this is merged I believe that we can tag the rendered versions.