### PR TITLE
Adding astropydev+numpydev job to the cron

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -86,8 +86,8 @@ matrix:
         # Try MacOS X, usually enough only to run from cron as hardly there are
         # issues that are not picked up by a linux worker
         - os: osx
-          stage: Cron
-          env: SETUP_CMD='test'
+          stage: Cron tests
+          env: SETUP_CMD='test' EVENT_TYPE='cron'
 
         # Do a coverage test.
         - os: linux
@@ -106,6 +106,14 @@ matrix:
                EVENT_TYPE='pull_request push cron'
         - os: linux
           env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
+
+        # Add a job that runs from cron only and tests against astropy dev and
+        # numpy dev to give a change for early discovery of issues and feedback
+        # for both developer teams.
+        - os: linux
+          stage: Cron tests
+          env: ASTROPY_VERSION=development NUMPY_VERSION=development
+               EVENT_TYPE='cron'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different


### PR DESCRIPTION
As it came up in https://github.com/astropy/astropy/pull/8808#issuecomment-501083180 it would be very valuable to receive early feedback. I don't think it's worth running this job on all commits for affiliated packages but running it more regularly than their development cycle would be useful.