### PR TITLE
Fix edit-on-github

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -159,10 +159,10 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 if eval(setup_cfg.get('edit_on_github')):
     extensions += ['sphinx_astropy.ext.edit_on_github']
 
-    versionmod = __import__(setup_cfg['package_name'] + '.version')
+    versionmod = import_module(setup_cfg['name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']
-    if versionmod.version.release:
-        edit_on_github_branch = "v" + versionmod.version.version
+    if versionmod.release:
+        edit_on_github_branch = "v" + versionmod.version
     else:
         edit_on_github_branch = "master"
 


### PR DESCRIPTION
Use the new way of using `import_module` instead of `__import__`, and fixes a remaining 'package_name'.

Found this while updating my own packages following the new template. It doesn't seem the `edit_on_github` functionality is tested...