### PR TITLE
Remove cextern directory based on input

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -54,3 +54,6 @@ if __name__ == '__main__':
 
     if '{{ cookiecutter.use_compiled_extensions }}' != 'y' or '{{ cookiecutter.include_example_code }}' != 'y':
         remove_file('{{ cookiecutter.module_name }}/example_c.pyx')
+
+    if '{{ cookiecutter.include_cextern_folder }}' != 'y':
+        remove_dir('cextern')


### PR DESCRIPTION
Currently the `cextern` directory is always created and thus `include_cextern_folder` has no effect.

fixes https://github.com/astropy/package-template/issues/403