### PR TITLE
Fixing Issue #450

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ requires =
 isolated_build = true
 
 [testenv]
+# Suppress display of matplotlib plots generated during docs build
+setenv = MPLBACKEND=agg
 
 # Pass through the following environemnt variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS


### PR DESCRIPTION
This is a (temporary?) fix to issue #450. It suppresses plots from being generated when running `tox -e build_docs`