### PR TITLE
Suppresses display of matplotlib plots generated during docs build

### DIFF
--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -11,6 +11,8 @@ requires =
 isolated_build = true
 
 [testenv]
+# Suppress display of matplotlib plots generated during docs build
+setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS


### PR DESCRIPTION
Suppresses display of matplotlib plots generated during docs build.

Closes #450.