### PR TITLE
Add linkcheck to tox envlist

### DIFF
--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{36,37,38}-test-numpy{116,117,118}
     py{36,37,38}-test-astropy{30,40,lts}
     build_docs
+    linkcheck
     codestyle
 requires =
     setuptools >= 30.3.0


### PR DESCRIPTION
The `linkcheck` env is defined, but missing from the `envlist`.