### PR TITLE
Spelling: licence->license

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
-The contents of this template are licenced under the terms of the following
-licence, this does not mean that your project has to be licenced under this
-licence.
+The contents of this template are licensed under the terms of the following
+license, this does not mean that your project has to be licensed under this
+license.
 
 
 Copyright (c) 2018, Astropy Developers

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -25,19 +25,19 @@ license_files = {"BSD 3-Clause": 'BSD3.rst',
                  "BSD 2-Clause": 'BSD2.rst'}
 
 
-def process_licence(licence_name):
-    if licence_name in license_files:
-        shutil.copyfile(os.path.join(PROJECT_DIRECTORY, 'licenses', license_files[licence_name]),
+def process_license(license_name):
+    if license_name in license_files:
+        shutil.copyfile(os.path.join(PROJECT_DIRECTORY, 'licenses', license_files[license_name]),
                         os.path.join(PROJECT_DIRECTORY, 'licenses', 'LICENSE.rst'))
 
-    if licence_name != "Other":
-        for licence_file in license_files.values():
-            os.remove(os.path.join(PROJECT_DIRECTORY, 'licenses', licence_file))
+    if license_name != "Other":
+        for license_file in license_files.values():
+            os.remove(os.path.join(PROJECT_DIRECTORY, 'licenses', license_file))
 
 
 if __name__ == '__main__':
 
-    process_licence('{{ cookiecutter.license }}')
+    process_license('{{ cookiecutter.license }}')
 
     if '{{ cookiecutter.use_travis_ci }}' != 'y':
         remove_file('.travis.yml')

--- a/{{ cookiecutter.package_name }}/licenses/README.rst
+++ b/{{ cookiecutter.package_name }}/licenses/README.rst
@@ -4,6 +4,6 @@ Licenses
 This directory holds license and credit information for the package,
 works the package is derived from, and/or datasets.
 
-Ensure that you pick a package licence which is in this folder and it matches
+Ensure that you pick a package license which is in this folder and it matches
 the one mentioned in the top level README.rst file. If you are using the
 pre-rendered version of this template check for the word 'Other' in the README.

--- a/{{ cookiecutter.package_name }}/licenses/TEMPLATE_LICENCE.rst
+++ b/{{ cookiecutter.package_name }}/licenses/TEMPLATE_LICENCE.rst
@@ -1,6 +1,6 @@
 This project is based upon the Astropy package template
-(https://github.com/astropy/package-template/) which is licenced under the terms
-of the following licence.
+(https://github.com/astropy/package-template/) which is licensed under the terms
+of the following license.
 
 ---
 


### PR DESCRIPTION
According to my dictionary, "licence" is a British English spelling whereas "license" is an American English spelling. By and large, the Astropy project documentation appears to be written in American English. This spelling change also makes the text consistent with the name of the license directory.