### PR TITLE
Remove warning about APE 17 migration guide

### DIFF
--- a/docs/ape17.rst
+++ b/docs/ape17.rst
@@ -1,9 +1,6 @@
 APE 17 Migration Guide
 ======================
 
-.. warning:: This guide is not yet ready for widespread use and may
-             still change significantly.
-
 The Astropy project is now transitioning from using astropy-helpers for
 infrastructure to more standard Python packaging tools. The motivation
 and implications of this are discussed in an Astropy Proposal for


### PR DESCRIPTION
Might be worth waiting a little in case anyone else replies on the core maintainers mailing list, but I think the warning is ready to be removed from the migration guide.

Once this is removed, we should probably start advertising the deprecation of astropy-helpers and the existence of the migration guide on astropy@python.org and astropy-dev.