### PR TITLE
Fix template for coverage reporting

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -154,8 +154,8 @@ script:
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the two lines below.
-    # pip install coveralls
-    # coveralls
+    # - pip install coveralls
+    # - coveralls
     # If codecov is set up for this package, uncomment the two lines below
-    # pip install codecov
-    # codecov
+    # - pip install codecov
+    # - codecov


### PR DESCRIPTION
Without this the lines are merged and travis will run e.g. `pip install coveralls coveralls` without actually running the `coveralls` command.