### PR TITLE
Have coverage upload only happen for cov tests

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -153,9 +153,13 @@ script:
     - tox $TOXARGS -- $TOXPOSARGS
 
 after_success:
-    # If coveralls.io is set up for this package, uncomment the two lines below.
-    # - pip install coveralls
-    # - coveralls
-    # If codecov is set up for this package, uncomment the two lines below
-    # - pip install codecov
-    # - codecov
+    # if either coveralls or codecov is used, uncomment the if and fi statements
+    # and the appropriate two lines inside the if statement
+    # - if [[ $TOXENV == *-cov ]]; then
+    #    # If coveralls.io is set up for this package, uncomment the two lines below.
+    #    pip install coveralls;
+    #    coveralls;
+    #    # If codecov is set up for this package, uncomment the two lines below
+    #    pip install codecov;
+    #    codecov;
+    #  fi

--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -162,4 +162,4 @@ after_success:
     #    # If codecov is set up for this package, uncomment the two lines below
     #    pip install codecov;
     #    codecov;
-    #  fi
+    # fi


### PR DESCRIPTION
The coverage upload should only happen for tests that have the cov tag.   This PR wraps the upload to coveralls and/or codecov in an if statement to have this happen.  This is the behavior for the astropy package currently.