### PR TITLE
Updating travis to add before install instructions

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -136,6 +136,12 @@ matrix:
         #   stage: Initial tests
         #   env: TOXENV=codestyle
 
+before_install:
+    # Create a coverage.xml for use by coveralls or codecov
+    - if [[ $TOXENV == *-cov ]]; then
+        export TOXPOSARGS=$TOXPOSARGS" --cov-report=xml:"$TRAVIS_BUILD_DIR"/coverage.xml";
+      fi
+
 install:
 
     # We now use the ci-helpers package to set up our Python environment


### PR DESCRIPTION
Updating default travis template to include generating coverage.xml for use by codecov and coveralls. This addresses #475 

An alternative to this is that the coverage.xml generation is controlled entirely in tox, but I think having an explicit example of how to set up `before install` in travis is a good idea.