### PR TITLE
private_project cookiecutter question

### DIFF
--- a/QUESTIONS.rst
+++ b/QUESTIONS.rst
@@ -22,3 +22,4 @@ a description of each of the prompts.
 15. ``required_dependencies``: Comma-separated list of required dependencies
 16. ``optional_dependencies``: Comma-separated list of optional dependencies
 17. ``minimum_python_version``: Version string of minimum supported Python version
+18. ``private_project``: Whether this is a private project or not.

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -22,6 +22,8 @@ be copied over manually if desired.
 
 - Added cron job for RST link checking [#482]
 
+- Added cookiecutter question for setting up a public versus private repo [#481]
+
 2.1 (unreleased)
 ----------------
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,6 @@
     "minimum_python_version": ["3.7", "3.8", "3.9"],
     "_copy_without_render": [
         ".github"
-    ]
+    ],
+    "private_project": "n"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,24 @@ documentation, read the :ref:`next-steps` for further information.
    updating
    ape17
 
+Taking a Project Public
+-----------------------
+
+If the 'private_project' option was set true when rendering with cookiecutter,
+then there a number of settings to consider when taking the project public.
+
+In ``.travis.yml``:
+
+For private repos, we whitelist only the main branch.
+Since on CIs, PRs to the main branch are still built, this means branches (with PRs) are only built once, saving time.
+On public repos this limitation is less important.
+
+::
+    branches:
+        only:
+            - master
+            - main  # as GitHub makes the transition
+
 
 Removal of Python 2 support
 ===========================

--- a/rendered.yml
+++ b/rendered.yml
@@ -17,3 +17,4 @@ default_context:
   minimum_python_version: "3.6"
   required_dependencies: "astropy"
   optional_dependencies: ""
+  private_project: "n"


### PR DESCRIPTION
On private repositories, every PR is build twice by the CI: once for the branch and once for the PR.
This changes it so that PRs are only built once, but still allows the master branch to be built after a PR.
Other branches are not built unless in a PR.

This option makes it easier to do code-dev on a project before taking it public.
I have added instructional docs about how to un-implement the private-repo options and take a project public.

In future, when further private-project options are added, they can be similarly documented.

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>