### PR TITLE
add linkcheck

### DIFF
--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -18,6 +18,8 @@ be copied over manually if desired.
 - Refactored the template to follow the recommendations in APE 17:
   https://github.com/astropy/astropy-APEs/blob/master/APE17.rst [#438]
 
+- Added cron job for RST link checking [#482]
+
 2.1 (unreleased)
 ----------------
 

--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -127,6 +127,17 @@ matrix:
           stage: Initial tests
           env: TOXENV=codestyle
 
+        # Run documentation link check in a cron job.
+        - language: python
+          python: 3.8
+          name: Documentation link check
+          stage: Cron tests
+          env: TOXENV=linkcheck
+          addons:
+              apt:
+                  packages:
+                      - graphviz
+
     allow_failures:
         # Do a PEP8 test with flake8
         # (do allow to fail unless your code completely compliant)
@@ -135,6 +146,7 @@ matrix:
         #   name: Code style checks
         #   stage: Initial tests
         #   env: TOXENV=codestyle
+
 
 before_install:
     # Create a coverage.xml for use by coveralls or codecov

--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -169,6 +169,15 @@ if setup_cfg.get('edit_on_github').lower() == 'true':
 # -- Resolving issue number to links in changelog -----------------------------
 github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
 
+
+# -- Options for linkcheck output -------------------------------------------
+linkcheck_retry = 5
+linkcheck_ignore = [
+    r'https://github\.com/{{ cookiecutter.github_project }}/(?:issues|pull)/\d+',
+]
+linkcheck_timeout = 180
+linkcheck_anchors = False
+
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----
 #
 # nitpicky = True


### PR DESCRIPTION
In `.tox` there's a link check option. I've enabled this in the `allow_failures` section of `.travis.yml`.
Looking in the closed issues and PRs, I don't see anything mentioning the link check, so if this wasn't enable for a reason, I'll close this PR.

edit: I see some discussion of this in #449 

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>