### PR TITLE
Conftest configure

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
@@ -1,7 +1,11 @@
-# This file is used to configure the behavior of pytest when using the Astropy
-# test infrastructure. It needs to live inside the package in order for it to
-# get picked up when running the tests inside an interpreter using
-# packagename.test
+"""Configure Test Suite.
+
+This file is used to configure the behavior of pytest when using the Astropy
+test infrastructure. It needs to live inside the package in order for it to
+get picked up when running the tests inside an interpreter using
+packagename.test
+
+"""
 
 import os
 
@@ -21,7 +25,13 @@ else:
 
 
 def pytest_configure(config):
+    """Configure Pytest with Astropy.
 
+    Parameters
+    ----------
+    config : pytest configuration
+
+    """
     if ASTROPY_HEADER:
 
         config.option.astropy_header = True


### PR DESCRIPTION
- the conftest code is given a doctoring from the top-level comments
- the `pytest_configure` function is likewise documented
- `import astropy.units as u` is auto-imported into docstring tests