### PR TITLE
use Major.minor syntax

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -52,7 +52,7 @@ highlight_language = 'python3'
 #needs_sphinx = '1.2'
 
 # To perform a Sphinx version check that needs to be more specific than
-# major.minor, call `check_sphinx_version("x.y.z")` here.
+# major.minor, call `check_sphinx_version("X.Y.Z")` here.
 # check_sphinx_version("1.2.1")
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
A very small change from `x.y.z` to `X.Y.Z`, to better follow the [semantic versioning](https://semver.org) standard syntax.

edit: changed. see history.

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>