### PR TITLE
Add pandoc for jupyter

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -16,6 +16,7 @@ addons:
     apt:
         packages:
             - graphviz
+            - pandoc
 
 
 stages:


### PR DESCRIPTION
jupyter notebooks require pandoc to show in docs. This is added to travis.