### PR TITLE
Add cookiecutter Q to init git

### DIFF
--- a/QUESTIONS.rst
+++ b/QUESTIONS.rst
@@ -22,3 +22,4 @@ a description of each of the prompts.
 15. ``required_dependencies``: Comma-separated list of required dependencies
 16. ``optional_dependencies``: Comma-separated list of optional dependencies
 17. ``minimum_python_version``: Version string of minimum supported Python version
+18. ``initialize_git_repo``: Whether to initialize the git repo using ``gitpython``.

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -22,6 +22,8 @@ be copied over manually if desired.
 
 - Added cron job for RST link checking [#482]
 
+- Add cookiecutter question to run ``git init .`` on render [#489]
+
 2.1 (unreleased)
 ----------------
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,6 @@
     "minimum_python_version": ["3.7", "3.8", "3.9"],
     "_copy_without_render": [
         ".github"
-    ]
+    ],
+    "initialize_git_repo": "n"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -54,3 +54,23 @@ if __name__ == '__main__':
 
     if '{{ cookiecutter.use_compiled_extensions }}' != 'y' or '{{ cookiecutter.include_example_code }}' != 'y':
         remove_file('{{ cookiecutter.module_name }}/example_c.pyx')
+
+    # NOTE! Has to be the last thing in __main__
+    # Code modified from @Cadair
+    # https://github.com/astropy/package-template/blob/34c5256e192113882fa52ccbb30a15cd002f3b6a/hooks/post_gen_project.py#L61
+    if '{{ cookiecutter.initialize_git_repo }}' == 'y':
+        try:
+            from git import Repo
+
+            new_repo = Repo.init(PROJECT_DIRECTORY)
+            new_repo.git.add('.')
+            new_repo.index.commit("Creation of {{ cookiecutter.package_name }}"
+                                  " from {{ cookiecutter._parent_project }}"
+                                  " package template")
+            # we do not push the repo for 2 reasons:
+            # 1) because we don't know to where it should be pushed
+            # 2) so that the user can modify / ammend the first commit.
+
+        except ImportError:
+            print("gitpython is not installed "
+                  "so the repository will not be initialized.")

--- a/rendered.yml
+++ b/rendered.yml
@@ -17,3 +17,4 @@ default_context:
   minimum_python_version: "3.6"
   required_dependencies: "astropy"
   optional_dependencies: ""
+  initialize_git_repo: "y"


### PR DESCRIPTION
Add a question, default no, to try and initialize the git repository using `gitpython`. Thanks @Cadair for the code.

@Cadair @mwcraig. If a ``gitpython`` solution isn't recommended, we could manually cd to the folder and run ``git init .`` Reduce package dependency.

Fixes #479 

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>