### PR TITLE
don’t doctest in extern by default

### DIFF
--- a/{{ cookiecutter.package_name }}/setup.cfg
+++ b/{{ cookiecutter.package_name }}/setup.cfg
@@ -47,6 +47,7 @@ testpaths = "{{ cookiecutter.module_name }}" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
+doctest_norecursedirs=*/{{ cookiecutter.module_name }}/extern/*
 addopts = --doctest-rst
 
 [coverage:run]

--- a/{{ cookiecutter.package_name }}/setup.cfg
+++ b/{{ cookiecutter.package_name }}/setup.cfg
@@ -47,7 +47,7 @@ testpaths = "{{ cookiecutter.module_name }}" "docs"
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-doctest_norecursedirs=*/{{ cookiecutter.module_name }}/extern/*
+doctest_norecursedirs={{ cookiecutter.module_name }}/extern/*
 addopts = --doctest-rst
 
 [coverage:run]

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/extern/__init__.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/extern/__init__.py
@@ -2,4 +2,14 @@
 """
 This packages contains python packages that are bundled with the package but
 are external to it, and hence are developed in a separate source tree.
+
+Docstrings of this directory contents are NOT tested by default.
+For example:
+
+    >>> this is tested = False
+
+To turn on doctests, remove the line
+``doctest_norecursedirs={{ cookiecutter.module_name }}/extern/*``
+in ``setup.cfg``.
+
 """


### PR DESCRIPTION
It's not meant to be safe by default. If it is, then this can be removed by the package author.

fixes: #486 

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>