### PR TITLE
modindex_common_prefix

### DIFF
--- a/{{ cookiecutter.package_name }}/docs/conf.py
+++ b/{{ cookiecutter.package_name }}/docs/conf.py
@@ -137,6 +137,9 @@ html_title = '{0} v{1}'.format(project, release)
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
 
+# Prefixes that are ignored for sorting the Python module index
+modindex_common_prefix = ["{{ cookiecutter.module_name }}."]
+
 
 # -- Options for LaTeX output -------------------------------------------------
 


### PR DESCRIPTION
This simplifies the search page.

From https://www.sphinx-doc.org/en/master/usage/configuration.html

> A list of prefixes that are ignored for sorting the Python module index (e.g., if this is set to ['foo.'], then foo.bar is shown under B, not F). This can be handy if you document a project that consists of a single package. Works only for the HTML builder currently. Default is [].
>
> New in version 0.6.

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>