### PR TITLE
Use setup_python.sh instead of setup_conda.sh

### DIFF
--- a/{{ cookiecutter.package_name }}/.travis.yml
+++ b/{{ cookiecutter.package_name }}/.travis.yml
@@ -151,7 +151,7 @@ install:
 
     - if [[ $TRAVIS_OS_NAME != linux ]]; then
         git clone --depth 1 git://github.com/astropy/ci-helpers.git;
-        source ci-helpers/travis/setup_conda.sh;
+        source ci-helpers/travis/setup_python.sh;
       fi
 
 script:


### PR DESCRIPTION
As done in the core astropy package - using conda is now no longer necessary