### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 # https://github.com/actions/download-artifact/issues/60
 jobs:
   upload:
-    name: Push template to master
+    name: Push template to main
     runs-on: ubuntu-latest
     if: github.repository == 'astropy/package-template' && github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     steps:
@@ -55,8 +55,8 @@ jobs:
       run: |
         cd ${{ github.workspace }}/test/rendered_dir
         git remote update
-        git checkout master
+        git checkout main
         rsync -avz --delete --exclude .git/ ../packagename/ ./
         git add -A
         git commit --allow-empty -m "Update rendered version to ""$GITHUB_SHA"
-        git push origin master
+        git push origin main

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Which will ask you a series of questions to configure your package.
 Manually
 ^^^^^^^^
 
-The ``master`` git branch of this repository contains a version of the
+The ``main`` git branch of this repository contains a version of the
 template populated with placeholders.  This allows the package template to be
 used directly without using cookiecutter, although a number of
 `manual steps  <http://docs.astropy.org/projects/package-template/en/latest/>`_

--- a/TEMPLATE_CHANGES.md
+++ b/TEMPLATE_CHANGES.md
@@ -16,7 +16,7 @@ be copied over manually if desired.
 - Removed Appveyor CI option. Use ``os: windows-latest`` in GitHub Actions. [#420]
 
 - Refactored the template to follow the recommendations in APE 17:
-  https://github.com/astropy/astropy-APEs/blob/master/APE17.rst [#438]
+  https://github.com/astropy/astropy-APEs/blob/main/APE17.rst [#438]
 
 - Switch to using GitHub Actions for CI; remove Travis config. [#449]
 

--- a/docs/ape17.rst
+++ b/docs/ape17.rst
@@ -5,7 +5,7 @@ The Astropy project is now transitioning from using astropy-helpers for
 infrastructure to more standard Python packaging tools. The motivation
 and implications of this are discussed in an Astropy Proposal for
 Enhancements: `APE 17: A roadmap for package infrastructure without
-astropy-helpers <https://github.com/astropy/astropy-APEs/blob/master/APE17.rst>`__.
+astropy-helpers <https://github.com/astropy/astropy-APEs/blob/main/APE17.rst>`__.
 The core astropy package has already migrated and these changes will be included
 in astropy v4.1.
 
@@ -270,7 +270,7 @@ Step 7c - Cython and Numpy build-time dependencies
 If your compiled extensions rely on the NumPy C API, you will need to
 declare Numpy as a build-time dependency in ``pyproject.toml``. Note
 that as described in `APE
-17 <https://github.com/astropy/astropy-APEs/blob/master/APE17.rst#build-time-dependencies>`__,
+17 <https://github.com/astropy/astropy-APEs/blob/main/APE17.rst#build-time-dependencies>`__,
 you need to pin the build-time Numpy dependency to the **oldest**
 supported Numpy version for each Python version. However, rather than doing this
 manually, you can add the ``oldest-supported-numpy`` package to the build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,8 +35,8 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'Astropy Package Template'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,8 +35,8 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 source_suffix = '.rst'
 
-# The main toctree document.
-main_doc = 'index'
+# The master toctree document.
+master_doc = 'index'
 
 # General information about the project.
 project = 'Astropy Package Template'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,7 @@ This package template now supports Python 3.6+ versions only. However we
 will provide critical bug fixes to the ``cookiecutter-2.x`` branch until
 the end of 2019.
 We also provide a Python 2 compatible rendered versions of the template in
-the ``master-py2`` branch.
+the ``main-py2`` branch.
 
 
 Indices and tables

--- a/docs/nextsteps.rst
+++ b/docs/nextsteps.rst
@@ -28,7 +28,7 @@ upon every push or pull request, ``ci_tests.yml``, and how to run scheduled test
 The default ``ci_tests.yml`` file contains a large number of builds against various versions of Python, astropy, and
 numpy, and you should choose the ones relevant to your project. Generally, you should aim to always have your
 ``main`` branch work with the latest stable and latest development version of astropy (i.e., the
-astropy git master branch) and the same versions of python and numpy supported
+astropy git main branch) and the same versions of python and numpy supported
 by astropy.  The template ``ci_tests.yml`` covers those versions; in some
 circumstances you may need to limit the versions your package covers.
 
@@ -79,7 +79,7 @@ Customizing the documentation CSS
 #################################
 
 As described in the documentation configuration file (`template/docs/conf.py
-<https://github.com/astropy/package-template/blob/master/docs/conf.py#L95>`_),
+<https://github.com/astropy/package-template/blob/main/docs/conf.py#L95>`_),
 the documentation uses a custom theme based on `bootstrap
 <http://getbootstrap.com/css/>`_. You can swap out this theme by editing the
 configuration file. You can also tweak aspects of the documentation theme by

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -65,4 +65,4 @@ this branch.
 
 3. Merge the branch::
 
-   $ git merge package-template/master
+   $ git merge package-template/main


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #505