### PR TITLE
Remove duplicate entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,6 @@ pip-wheel-metadata
 .tox
 .*.sw[op]
 *~
-.project
-.pydevproject
-.settings
 
 # Mac OSX
 .DS_Store


### PR DESCRIPTION
These entries are also listed under the "Eclipse editor project files" section.