### PR TITLE
TST: Use nightly astropy

### DIFF
--- a/{{ cookiecutter.package_name }}/tox.ini
+++ b/{{ cookiecutter.package_name }}/tox.ini
@@ -12,6 +12,7 @@ requires =
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    NIGHTLY2 = https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/nightly/pypi/simple
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
@@ -58,7 +59,7 @@ deps =
     astropylts: astropy==4.0.*
 
     devdeps: :NIGHTLY:numpy
-    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: :NIGHTLY2:astropy
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
Fix #468 

Also see astropy/astropy#11522

(Nothing much we can do about the other stuff like `stingray` but we got `numpy` and `astropy` covered already.)