### PR TITLE
MNT: Stop using enable_deprecations_as_exceptions

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/conftest.py
@@ -9,19 +9,11 @@ get picked up when running the tests inside an interpreter using
 
 import os
 
-from astropy.version import version as astropy_version
-
-# For Astropy 3.0 and later, we can use the standalone pytest plugin
-if astropy_version < '3.0':
-    from astropy.tests.pytest_plugins import *  # noqa
-    del pytest_report_header
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
     ASTROPY_HEADER = True
-else:
-    try:
-        from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
-        ASTROPY_HEADER = True
-    except ImportError:
-        ASTROPY_HEADER = False
+except ImportError:
+    ASTROPY_HEADER = False
 
 
 def pytest_configure(config):
@@ -44,16 +36,3 @@ def pytest_configure(config):
         from . import __version__
         packagename = os.path.basename(os.path.dirname(__file__))
         TESTED_VERSIONS[packagename] = __version__
-
-# Uncomment the last two lines in this block to treat all DeprecationWarnings as
-# exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-# from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-# enable_deprecations_as_exceptions()


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .