### PR TITLE
add README note about OA guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,19 @@ Astropy package template
 
 |powered|   -   **cookiecutter branch:** |ci cookiecutter|
 
+Pending Deprecation Warning
+---------------------------
+This template is in the process of being subsumed by the 
+`OpenAstronomy packaging guide <https://github.com/OpenAstronomy/packaging-guide>`__,
+which reflects more up-to-date Python packaging techniques than this template. In 
+the future this template will be replaced by a guide built from the OA guide specific
+to Astropy, but in the mine time, if you are starting a new project you may wish to
+start from the OA guide.
+
+
+Introduction
+------------
+
 This is a package template provided by the Astropy project.
 
 Using this template, packages can make use of the setup, installation, and documentation

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Pending Deprecation Warning
 This template is in the process of being subsumed by the 
 `OpenAstronomy packaging guide <https://github.com/OpenAstronomy/packaging-guide>`__,
 which reflects more up-to-date Python packaging techniques than this template. In 
-the future this template will be replaced by a guide built from the OA guide specific
+the future this template may be replaced by a guide built from the OA guide specific
 to Astropy, but in the meantime, if you are starting a new project you may wish to
 start from the OA guide.
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This template is in the process of being subsumed by the
 `OpenAstronomy packaging guide <https://github.com/OpenAstronomy/packaging-guide>`__,
 which reflects more up-to-date Python packaging techniques than this template. In 
 the future this template will be replaced by a guide built from the OA guide specific
-to Astropy, but in the mine time, if you are starting a new project you may wish to
+to Astropy, but in the meantime, if you are starting a new project you may wish to
 start from the OA guide.
 
 


### PR DESCRIPTION
As discussed in the Astropy dev telecon today, this change is the first step in shifting the package template machinery to the OA guide approach.

cc @nstarman @Cadair @astrofrog @larrybradley 